### PR TITLE
Add Local Storage and Persistence Functionality for the Scheduler Module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,19 +20,22 @@ let package = Package(
         .library(name: "SpeziScheduler", targets: ["SpeziScheduler"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.5.0"))
+        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.3.0"))
     ],
     targets: [
         .target(
             name: "SpeziScheduler",
             dependencies: [
-                .product(name: "Spezi", package: "Spezi")
+                .product(name: "Spezi", package: "Spezi"),
+                .product(name: "SpeziLocalStorage", package: "SpeziStorage")
             ]
         ),
         .testTarget(
             name: "SpeziSchedulerTests",
             dependencies: [
-                .target(name: "SpeziScheduler")
+                .target(name: "SpeziScheduler"),
+                .product(name: "SpeziLocalStorage", package: "SpeziStorage")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.3.0"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.3.1"))
     ],
     targets: [
         .target(

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -50,7 +50,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
             .sink {
                 _Concurrency.Task {
                     do {
-                        try await self.localStorage.store(self.tasks)
+                        try self.localStorage.store(self.tasks)
                     } catch {
                         print(error)
                     }
@@ -59,14 +59,12 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
             .store(in: &cancellables)
         
         
-        _Concurrency.Task {
-            guard let storedTasks = try? await localStorage.read([Task<Context>].self) else {
-                schedule(tasks: initialTasks)
-                return
-            }
-            
-            schedule(tasks: storedTasks)
+        guard let storedTasks = try? localStorage.read([Task<Context>].self) else {
+            schedule(tasks: initialTasks)
+            return
         }
+        
+        schedule(tasks: storedTasks)
     }
     
     

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -74,8 +74,7 @@ final class SchedulerTests: XCTestCase {
     }
     
     
-    func testCompleteEvents() throws { // swiftlint:disable:this function_body_length
-        // We use longer functions to test the different observable states in one test function.
+    func testCompleteEvents() throws {
         let numberOfEvents = 6
         
         let testTask = Task(

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -103,8 +103,6 @@ final class SchedulerTests: XCTestCase {
         )
         scheduler.schedule(task: testTask2)
         
-        // try await _Concurrency.Task.sleep(for: .seconds(0.1))
-        
         let expectationCompleteEvents = XCTestExpectation(description: "Complete all events")
         expectationCompleteEvents.expectedFulfillmentCount = 12
         expectationCompleteEvents.assertForOverFulfill = true
@@ -122,15 +120,10 @@ final class SchedulerTests: XCTestCase {
             expectationObservedObject.fulfill()
         }
         
-        print(scheduler.tasks)
         let events: Set<Event> = Set(scheduler.tasks.flatMap { $0.events() })
         _Concurrency.Task {
-            print(events)
-            print(events.count)
             for event in events {
-                print("event.id \(event.id) - event.complete: \(event.complete)")
                 await event.complete(true)
-                print("event.id \(event.id) - event.complete: \(event.complete)")
                 expectationCompleteEvents.fulfill()
             }
         }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -16,7 +16,20 @@ typealias TestAppScheduler = Scheduler<TestAppStandard, String>
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: TestAppStandard()) {
-            TestAppScheduler()
+            TestAppScheduler(
+                tasks: [
+                    Task(
+                        title: "Original Task",
+                        description: "Original Task",
+                        schedule: Schedule(
+                            start: .now,
+                            dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                            end: .numberOfEvents(1)
+                        ),
+                        context: "Original Task!"
+                    )
+                ]
+            )
         }
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import XCTestExtensions
 
 
 class TestAppUITests: XCTestCase {
@@ -14,14 +15,74 @@ class TestAppUITests: XCTestCase {
         try super.setUpWithError()
         
         continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
     }
     
     
-    func testSpezi() throws {
+    func testSchedulerLocalStorage() throws {
         let app = XCUIApplication()
-        app.launch()
-        
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
+        
+        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        
+        app.buttons["Fulfill Event"].tap()
+        app.assert(tasks: 1, events: 1, fulfilledEvents: 1)
+        
+        app.buttons["Unfulfull Event"].tap()
+        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        
+        app.buttons["Add Task"].tap()
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 0)
+        
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 3)
+        
+        
+        app.terminate()
+        app.launch()
+        
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 3)
+        
+        app.buttons["Unfulfull Event"].tap()
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
+        
+        
+        app.terminate()
+        app.launch()
+        
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
+        
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Unfulfull Event"].tap()
+        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
+        
+        app.buttons["Add Task"].tap()
+        app.assert(tasks: 3, events: 5, fulfilledEvents: 2)
+        
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.assert(tasks: 3, events: 5, fulfilledEvents: 5)
+        
+        
+        app.terminate()
+        app.launch()
+        
+        app.assert(tasks: 3, events: 5, fulfilledEvents: 5)
+    }
+}
+
+
+extension XCUIApplication {
+    fileprivate func assert(tasks: Int, events: Int, fulfilledEvents: Int) {
+        XCTAssert(staticTexts["\(tasks) Tasks"].waitForExistence(timeout: 2))
+        XCTAssert(staticTexts["\(events) Events"].waitForExistence(timeout: 2))
+        XCTAssert(staticTexts["Fulfilled \(fulfilledEvents) Events"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -14,8 +14,9 @@
 		2F9F4D8729B80AB100ABE259 /* TestAppStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F4D8629B80AB100ABE259 /* TestAppStandard.swift */; };
 		2F9F4D8A29B80B2400ABE259 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D8929B80B2400ABE259 /* Spezi */; };
 		2F9F4D8C29B80BD100ABE259 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F4D8B29B80BD100ABE259 /* ContentView.swift */; };
-		2F9F4D8E29B80C5600ABE259 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2F9F4D8D29B80C5600ABE259 /* SpeziScheduler */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		2FE0B6E72A14C65900818AE9 /* SpeziScheduler in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE0B6E62A14C65900818AE9 /* SpeziScheduler */; };
+		2FE0B6EA2A14D82600818AE9 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE0B6E92A14D82600818AE9 /* XCTestExtensions */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,7 +30,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2F68C3C6292E9F8F00B3E12C /* SpeziScheduler */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziScheduler; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -39,6 +39,7 @@
 		2F9F4D8B29B80BD100ABE259 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		2FE0B6E52A14C64E00818AE9 /* SpeziScheduler */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziScheduler; path = ../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,7 +49,7 @@
 			files = (
 				2F68C3C8292EA52000B3E12C /* Spezi in Frameworks */,
 				2F9F4D8A29B80B2400ABE259 /* Spezi in Frameworks */,
-				2F9F4D8E29B80C5600ABE259 /* SpeziScheduler in Frameworks */,
+				2FE0B6E72A14C65900818AE9 /* SpeziScheduler in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -56,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FE0B6EA2A14D82600818AE9 /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,7 +68,7 @@
 			isa = PBXGroup;
 			children = (
 				2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */,
-				2F68C3C6292E9F8F00B3E12C /* SpeziScheduler */,
+				2FE0B6E52A14C64E00818AE9 /* SpeziScheduler */,
 				2F6D139428F5F384007C25D6 /* TestApp */,
 				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
@@ -129,7 +131,7 @@
 			packageProductDependencies = (
 				2F68C3C7292EA52000B3E12C /* Spezi */,
 				2F9F4D8929B80B2400ABE259 /* Spezi */,
-				2F9F4D8D29B80C5600ABE259 /* SpeziScheduler */,
+				2FE0B6E62A14C65900818AE9 /* SpeziScheduler */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -149,6 +151,9 @@
 				2F6D13AE28F5F386007C25D6 /* PBXTargetDependency */,
 			);
 			name = TestAppUITests;
+			packageProductDependencies = (
+				2FE0B6E92A14D82600818AE9 /* XCTestExtensions */,
+			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -183,6 +188,7 @@
 			mainGroup = 2F6D138928F5F384007C25D6;
 			packageReferences = (
 				2F9F4D8829B80B2400ABE259 /* XCRemoteSwiftPackageReference "Spezi" */,
+				2FE0B6E82A14D82600818AE9 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
@@ -611,6 +617,14 @@
 				minimumVersion = 0.5.0;
 			};
 		};
+		2FE0B6E82A14D82600818AE9 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.4.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -623,9 +637,14 @@
 			package = 2F9F4D8829B80B2400ABE259 /* XCRemoteSwiftPackageReference "Spezi" */;
 			productName = Spezi;
 		};
-		2F9F4D8D29B80C5600ABE259 /* SpeziScheduler */ = {
+		2FE0B6E62A14C65900818AE9 /* SpeziScheduler */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziScheduler;
+		};
+		2FE0B6E92A14D82600818AE9 /* XCTestExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2FE0B6E82A14D82600818AE9 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			productName = XCTestExtensions;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2F68C3C6292E9F8F00B3E12C /* Spezi */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Spezi; path = ../..; sourceTree = "<group>"; };
+		2F68C3C6292E9F8F00B3E12C /* SpeziScheduler */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziScheduler; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,7 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */,
-				2F68C3C6292E9F8F00B3E12C /* Spezi */,
+				2F68C3C6292E9F8F00B3E12C /* SpeziScheduler */,
 				2F6D139428F5F384007C25D6 /* TestApp */,
 				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
@@ -379,7 +379,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezischeduler.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -410,7 +410,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezischeduler.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -539,7 +539,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezischeduler.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -557,7 +557,7 @@
 				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.Spezi.testappuitests;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;


### PR DESCRIPTION
# Add Local Storage and Persistence Functionality for the Scheduler Module

## :recycle: Current situation & Problem
- Task and Events in the Scheduler Module are currently not persisted across launches of the application.

## :bulb: Proposed solution
- This PR uses the Spezi Storage module to enable a local storage of the schedule, tasks, and events in the Spezi Scheduler module.

### Testing
- Adds UI and unit tests.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
