### PR TITLE
Randomize Scheduling of Task in Time Interval

### DIFF
--- a/Sources/SpeziScheduler/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule.swift
@@ -136,8 +136,8 @@ public struct Schedule: Codable, Sendable {
         switch repetition {
         case let .matching(matchingStartDateComponents):
             startDateComponents = matchingStartDateComponents
-        case let .randomInvervalBetween(randomInvervalBetweensStartDateComponents, _):
-            startDateComponents = randomInvervalBetweensStartDateComponents
+        case let .randomInvervalBetween(randomInvervalStartDateComponents, _):
+            startDateComponents = randomInvervalStartDateComponents
         }
         
         

--- a/Sources/SpeziScheduler/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule.swift
@@ -162,7 +162,23 @@ public struct Schedule: Codable, Sendable {
                 return
             }
             
-            dates.append(result)
+            switch repetition {
+            case .matching:
+                dates.append(result)
+            case let .randomInvervalBetween(_, randomInvervalEndDateComponents):
+                let resultEndDate = calendar
+                    .nextDate(
+                        after: result,
+                        matching: randomInvervalEndDateComponents,
+                        matchingPolicy: .nextTime
+                    )
+                    ?? result
+                
+                let timeInterval = resultEndDate.timeIntervalSince(result)
+                let randomDisplacement = Double.random(in: 0...timeInterval)
+                
+                dates.append(result.addingTimeInterval(randomDisplacement))
+            }
         }
         return dates
     }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -71,13 +71,13 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     /// Schedule a new ``Task`` in the ``Scheduler`` module.
     /// - Parameter task: The new ``Task`` instance that should be scheduled.
     public func schedule(task: Task<Context>) {
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue(label: "Scheduler Task Queue", qos: .background).async {
             let futureEvents = task.events(from: .now.addingTimeInterval(-1), to: .endDate(.distantFuture))
             self.timers.reserveCapacity(self.timers.count + futureEvents.count)
             
             for futureEvent in futureEvents {
                 let scheduledTimer = Timer(
-                    timeInterval: max(Date.now.distance(to: futureEvent.scheduledAt), TimeInterval.leastNonzeroMagnitude),
+                    timeInterval: max(Date.now.distance(to: futureEvent.scheduledAt), 0.01),
                     repeats: false,
                     block: { timer in
                         timer.invalidate()

--- a/Sources/SpeziScheduler/SpeziScheduler.docc/SchedulingATask.md
+++ b/Sources/SpeziScheduler/SpeziScheduler.docc/SchedulingATask.md
@@ -24,12 +24,14 @@ let surveyTask = Task(
     description: "Take a survey",
     schedule: Schedule(
         start: .now,
-        dateComponents: .init(day: 1), // daily
+        repetition: .matching(.init(day: 1)), // daily
         end: .numberOfEvents(7)
     ),
     context: "This is a test context"
 )
 ```
+
+The ``Schedule`` type also allows the customization of the repeition using the ``Schedule/Repetition-swift.enum`` type including the randomization between two date components, and the definition of the end of the schedule using the ``Schedule/End-swift.enum`` type.
 
 Now, we will use the scheduler to schedule our task. Note that the scheduler requires a `Standard` to be defined.
 

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Combine
 import Foundation
 
 
@@ -33,7 +34,10 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     public let schedule: Schedule
     /// The customized context of the ``Task``.
     public let context: Context
+    
     @Published var completedEvents: [Date: Event]
+    
+    private var cancellables: Set<AnyCancellable> = []
     
     
     /// Creates a new ``Task`` instance.
@@ -49,6 +53,12 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
         self.schedule = schedule
         self.context = context
         self.completedEvents = [:]
+        
+        schedule.objectWillChange
+            .sink {
+                self.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
     
     
@@ -77,7 +87,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     ///   - start: The start of the requested series of `Event`s. The start date of the ``Task/schedule`` is used if the start date is before the ``Task/schedule``'s start date.
     ///   - end: The end of the requested series of `Event`s. The end (number of events or date) of the ``Task/schedule`` is used if the start date is after the ``Task/schedule``'s end.
     public func events(from start: Date? = nil, to end: Schedule.End? = nil) -> [Event] {
-        let dates = schedule.dates(from: start, to: end, eventContext: self)
+        let dates = schedule.dates(from: start, to: end)
         
         return dates
             .map { date in

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -77,7 +77,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     ///   - start: The start of the requested series of `Event`s. The start date of the ``Task/schedule`` is used if the start date is before the ``Task/schedule``'s start date.
     ///   - end: The end of the requested series of `Event`s. The end (number of events or date) of the ``Task/schedule`` is used if the start date is after the ``Task/schedule``'s end.
     public func events(from start: Date? = nil, to end: Schedule.End? = nil) -> [Event] {
-        let dates = schedule.dates(from: start, to: end)
+        let dates = schedule.dates(from: start, to: end, eventContext: self)
         
         return dates
             .map { date in

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -76,7 +76,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     /// - Parameters:
     ///   - start: The start of the requested series of `Event`s. The start date of the ``Task/schedule`` is used if the start date is before the ``Task/schedule``'s start date.
     ///   - end: The end of the requested series of `Event`s. The end (number of events or date) of the ``Task/schedule`` is used if the start date is after the ``Task/schedule``'s end.
-    public func events(from start: Date? = nil, to end: Schedule.ScheduleEnd? = nil) -> [Event] {
+    public func events(from start: Date? = nil, to end: Schedule.End? = nil) -> [Event] {
         let dates = schedule.dates(from: start, to: end)
         
         return dates

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -48,7 +48,7 @@ final class SchedulerTests: XCTestCase {
             description: "This is a test task",
             schedule: Schedule(
                 start: .now,
-                dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a test context"
@@ -82,7 +82,7 @@ final class SchedulerTests: XCTestCase {
             description: "This is a test task",
             schedule: Schedule(
                 start: .now.addingTimeInterval(42_000),
-                dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a test context"
@@ -95,7 +95,7 @@ final class SchedulerTests: XCTestCase {
             description: "This is a second test task",
             schedule: Schedule(
                 start: .now.addingTimeInterval(42_000),
-                dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a second test context"
@@ -141,7 +141,7 @@ final class SchedulerTests: XCTestCase {
                 description: "This is a test task",
                 schedule: Schedule(
                     start: .now,
-                    dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                    repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                     end: .numberOfEvents(2)
                 ),
                 context: "This is a test context"
@@ -151,7 +151,7 @@ final class SchedulerTests: XCTestCase {
                 description: "This is a second test task",
                 schedule: Schedule(
                     start: .now.addingTimeInterval(10),
-                    dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                    repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                     end: .numberOfEvents(2)
                 ),
                 context: "This is a second test context"
@@ -199,8 +199,12 @@ final class SchedulerTests: XCTestCase {
             "id": "DEDDE3FF-0A75-4A8C-9F0D-75AD417F1104",
             "schedule" : {
                 "calendar": "current",
-                "dateComponents": {
-                    "nanosecond": 500000000
+                "repetition" : {
+                    "matching" : {
+                        "_0" : {
+                            "nanosecond" : 500000000
+                        }
+                    }
                 },
                 "end" : {
                     "numberOfEvents": {

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -44,11 +44,11 @@ final class SchedulerTests: XCTestCase {
         let numberOfEvents = 6
         
         let testTask = Task(
-            title: "Test Task",
-            description: "This is a test task",
+            title: "Observable Object Test Task",
+            description: "This is a Observable Object Test task",
             schedule: Schedule(
                 start: .now,
-                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 0)), // Every full second
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a test context"
@@ -59,16 +59,59 @@ final class SchedulerTests: XCTestCase {
         expectation.expectedFulfillmentCount = numberOfEvents
         expectation.assertForOverFulfill = true
         
-        var eventCount = 0
-        
         let cancellable = scheduler.objectWillChange.sink {
-            eventCount += 1
-            XCTAssertEqual(eventCount, scheduler.tasks.first?.events(to: .endDate(.now)).count)
-            XCTAssertEqual(numberOfEvents - eventCount, scheduler.tasks.first?.events(from: .now).count)
+            let events = scheduler.tasks.flatMap { $0.events() }
+            let completedEvents = events.filter { $0.complete }.count
+            let uncompletedEvents = events.filter { !$0.complete }.count
+            
+            XCTAssertEqual(numberOfEvents, uncompletedEvents + completedEvents)
             expectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: TimeInterval(numberOfEvents + 3))
+        wait(for: [expectation], timeout: TimeInterval(numberOfEvents + 2))
+        
+        cancellable.cancel()
+    }
+    
+    func testRandomSchedulerFunctionality() throws {
+        let numberOfEvents = 10
+        
+        let testTask = Task(
+            title: "Random Scheduler Test Task",
+            description: "Random Scheduler Test task",
+            schedule: Schedule(
+                start: .now,
+                repetition: .randomBetween( // Randomely scheduled in the first half of each second.
+                    start: .init(nanosecond: 450_000_000),
+                    end: .init(nanosecond: 550_000_000)
+                ),
+                end: .numberOfEvents(numberOfEvents)
+            ),
+            context: "This is a test context"
+        )
+        let scheduler = createScheduler(withInitialTasks: testTask)
+        
+        let expectation = XCTestExpectation(description: "Get Updates for all scheduled events.")
+        expectation.expectedFulfillmentCount = numberOfEvents + 1
+        expectation.assertForOverFulfill = true
+        
+        let cancellable = scheduler.objectWillChange.sink {
+            let events = scheduler.tasks.flatMap { $0.events() }
+            let completedEvents = events.filter { $0.complete }.count
+            let uncompletedEvents = events.filter { !$0.complete }.count
+            
+            XCTAssertEqual(numberOfEvents, uncompletedEvents + completedEvents)
+            expectation.fulfill()
+        }
+        
+        let events = scheduler.tasks.flatMap { $0.events() }
+        for event in events {
+            let nanosecondsElement = Calendar.current.dateComponents([.nanosecond], from: event.scheduledAt).nanosecond ?? 0
+            XCTAssertGreaterThan(nanosecondsElement, 450_000_000)
+            XCTAssertLessThan(nanosecondsElement, 550_000_000)
+        }
+        
+        wait(for: [expectation], timeout: TimeInterval(numberOfEvents + 2))
         
         cancellable.cancel()
     }
@@ -82,7 +125,7 @@ final class SchedulerTests: XCTestCase {
             description: "This is a test task",
             schedule: Schedule(
                 start: .now.addingTimeInterval(42_000),
-                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 0)), // Every full second
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a test context"
@@ -95,7 +138,7 @@ final class SchedulerTests: XCTestCase {
             description: "This is a second test task",
             schedule: Schedule(
                 start: .now.addingTimeInterval(42_000),
-                repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                repetition: .matching(.init(nanosecond: 0)), // Every full second
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a second test context"
@@ -115,7 +158,7 @@ final class SchedulerTests: XCTestCase {
             let completedEvents = events.filter { $0.complete }.count
             let uncompletedEvents = events.filter { !$0.complete }.count
             
-            XCTAssertEqual(12, uncompletedEvents + completedEvents)
+            XCTAssertEqual(numberOfEvents * 2, uncompletedEvents + completedEvents)
             expectationObservedObject.fulfill()
         }
         
@@ -141,7 +184,7 @@ final class SchedulerTests: XCTestCase {
                 description: "This is a test task",
                 schedule: Schedule(
                     start: .now,
-                    repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                    repetition: .matching(.init(nanosecond: 0)), // Every full second
                     end: .numberOfEvents(2)
                 ),
                 context: "This is a test context"
@@ -151,7 +194,7 @@ final class SchedulerTests: XCTestCase {
                 description: "This is a second test task",
                 schedule: Schedule(
                     start: .now.addingTimeInterval(10),
-                    repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                    repetition: .matching(.init(nanosecond: 0)), // Every full second
                     end: .numberOfEvents(2)
                 ),
                 context: "This is a second test context"

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -45,7 +45,7 @@ struct ContentView: View {
                     description: "New Task",
                     schedule: Schedule(
                         start: .now,
-                        dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                        repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                         end: .numberOfEvents(2)
                     ),
                     context: "New Task!"

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -45,7 +45,7 @@ struct ContentView: View {
                     description: "New Task",
                     schedule: Schedule(
                         start: .now,
-                        repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                        repetition: .matching(.init(nanosecond: 0)), // Every full second
                         end: .numberOfEvents(2)
                     ),
                     context: "New Task!"

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -23,7 +23,7 @@ class TestAppDelegate: SpeziAppDelegate {
                         description: "Original Task",
                         schedule: Schedule(
                             start: .now,
-                            dateComponents: .init(nanosecond: 500_000_000), // every 0.5 seconds
+                            repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
                             end: .numberOfEvents(1)
                         ),
                         context: "Original Task!"

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -23,7 +23,7 @@ class TestAppDelegate: SpeziAppDelegate {
                         description: "Original Task",
                         schedule: Schedule(
                             start: .now,
-                            repetition: .matching(.init(nanosecond: 500_000_000)), // every 0.5 seconds
+                            repetition: .matching(.init(nanosecond: 0)), // Every full second
                             end: .numberOfEvents(1)
                         ),
                         context: "Original Task!"


### PR DESCRIPTION
# Randomize Scheduling of Task in Time Interval

## :recycle: Current situation & Problem
- The current Scheduler API does not allow the scheduling of a task in a random time interval between two defined times.

## :bulb: Proposed solution
- Creates an API that defines a `Repetition` type to define a start and end time of the scheduled task.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
