### PR TITLE
Add Support for Local Notifications

### DIFF
--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 
 /// An  ``Event`` describes a unique point in time when a ``Task`` is scheduled. Use events to display the recurring nature of a ``Task`` to a user.
@@ -18,25 +19,28 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         // We use the underscore as the corresponding property `_scheduledAt` uses an underscore as it is a private property.
         // swiftlint:disable:next identifier_name
         case _scheduledAt = "scheduledAt"
+        case scheduledNotification
         case completedAt
     }
     
     
     private let lock = Lock()
+    private let timer: Timer? = nil
     private let _scheduledAt: Date
+    private var scheduledNotification: UUID?
     /// The date when the ``Event`` was completed.
     public private(set) var completedAt: Date?
-    weak var eventContext: EventContext?
+    weak var taskReference: (any TaskReference)?
     
     
     /// The date when the ``Event`` is scheduled at.
     public var scheduledAt: Date {
-        guard let eventsContainer = eventContext else {
+        guard let taskReference = taskReference else {
             return _scheduledAt
         }
         
         let timeZoneDifference = TimeInterval(
-            eventsContainer.schedule.calendar.timeZone.secondsFromGMT(for: .now) - Calendar.current.timeZone.secondsFromGMT(for: .now)
+            taskReference.schedule.calendar.timeZone.secondsFromGMT(for: .now) - Calendar.current.timeZone.secondsFromGMT(for: .now)
         )
         return _scheduledAt.addingTimeInterval(timeZoneDifference)
     }
@@ -47,23 +51,77 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     }
     
     public var id: String {
-        "\(eventContext?.id.uuidString ?? "").\(_scheduledAt.description)"
+        "\(taskReference?.id.uuidString ?? "").\(_scheduledAt.description)"
     }
     
     
-    init(scheduledAt: Date, eventsContainer: EventContext) {
+    init(scheduledAt: Date, eventsContainer: any TaskReference) {
         self._scheduledAt = scheduledAt
-        self.eventContext = eventsContainer
+        self.taskReference = eventsContainer
+    }
+    
+    
+    deinit {
+        timer?.invalidate()
+    }
+    
+    
+    func scheduleTaskAndNotification() {
+        guard let taskReference = taskReference else {
+            return
+        }
+        
+        // Schedule the timer for the event that refreshes the Observable Object.
+        if timer == nil {
+            let scheduledTimer = Timer(
+                timeInterval: max(Date.now.distance(to: scheduledAt), 0.01),
+                repeats: false,
+                block: { timer in
+                    timer.invalidate()
+                    taskReference.sendObjectWillChange()
+                }
+            )
+            
+            RunLoop.current.add(scheduledTimer, forMode: .common)
+        }
+        
+        // Only schedule a notification if it is enabled in a task and the notification has not yet been scheduled.
+        if taskReference.notifications && scheduledNotification == nil {
+            _Concurrency.Task {
+                let notificationCenter = UNUserNotificationCenter.current()
+                let authorizationStatus = await notificationCenter.notificationSettings().authorizationStatus
+                switch authorizationStatus {
+                case .notDetermined, .denied:
+                    return
+                default:
+                    let content = UNMutableNotificationContent()
+                    content.title = taskReference.title
+                    content.body = taskReference.description
+                    
+                    let trigger = UNTimeIntervalNotificationTrigger(
+                        timeInterval: max(self.scheduledAt.timeIntervalSince(.now), TimeInterval.leastNonzeroMagnitude),
+                        repeats: false
+                    )
+                    
+                    let identifier = UUID()
+                    let request = UNNotificationRequest(identifier: identifier.uuidString, content: content, trigger: trigger)
+                    
+                    try await notificationCenter.add(request)
+                    
+                    self.scheduledNotification = identifier
+                }
+            }
+        }
     }
     
     
     public static func == (lhs: Event, rhs: Event) -> Bool {
-        lhs.eventContext?.id == rhs.eventContext?.id && lhs.scheduledAt == rhs.scheduledAt
+        lhs.taskReference?.id == rhs.taskReference?.id && lhs.scheduledAt == rhs.scheduledAt
     }
     
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(eventContext?.id)
+        hasher.combine(taskReference?.id)
         hasher.combine(_scheduledAt)
     }
     
@@ -73,9 +131,9 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         await lock.enter {
             if newValue {
                 completedAt = Date()
-                eventContext?.completedEvents[_scheduledAt] = self
+                taskReference?.completedEvents[_scheduledAt] = self
             } else {
-                eventContext?.completedEvents[_scheduledAt] = nil
+                taskReference?.completedEvents[_scheduledAt] = nil
                 completedAt = nil
             }
         }

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -129,6 +129,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             } else {
                 completedAt = nil
             }
+            
             taskReference?.sendObjectWillChange()
         }
     }

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -61,8 +61,8 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     }
     
     
-    deinit {
-        timer?.invalidate()
+    public static func == (lhs: Event, rhs: Event) -> Bool {
+        lhs.taskReference?.id == rhs.taskReference?.id && lhs.scheduledAt == rhs.scheduledAt
     }
     
     
@@ -115,11 +115,6 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     }
     
     
-    public static func == (lhs: Event, rhs: Event) -> Bool {
-        lhs.taskReference?.id == rhs.taskReference?.id && lhs.scheduledAt == rhs.scheduledAt
-    }
-    
-    
     public func hash(into hasher: inout Hasher) {
         hasher.combine(taskReference?.id)
         hasher.combine(_scheduledAt)
@@ -142,5 +137,10 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     /// Toggle the ``Event``'s ``Event/complete`` state.
     public func toggle() async {
         await complete(!complete)
+    }
+    
+    
+    deinit {
+        timer?.invalidate()
     }
 }

--- a/Sources/SpeziScheduler/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule.swift
@@ -160,7 +160,6 @@ public class Schedule: Codable, @unchecked Sendable, ObservableObject {
         let end = End.minimum(end ?? self.end, self.end)
         
         var dates: [Date] = []
-        var numberOfEvents = 0
         
         
         let startDateComponents: DateComponents
@@ -179,12 +178,11 @@ public class Schedule: Codable, @unchecked Sendable, ObservableObject {
                 return
             }
             
-            numberOfEvents += 1
             if result < (searchStart ?? self.start) {
                 return
             }
             
-            if let maxNumberOfEvents = end.numberOfEvents, numberOfEvents > maxNumberOfEvents {
+            if let maxNumberOfEvents = end.numberOfEvents, dates.count >= maxNumberOfEvents {
                 stop = true
                 return
             }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import UserNotifications
 import Spezi
 import SpeziLocalStorage
 
@@ -22,8 +23,8 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     
     public private(set) var tasks: [Task<Context>] = []
     private var initialTasks: [Task<Context>]
-    private var timers: [Timer] = []
     private var cancellables: Set<AnyCancellable> = []
+    private let taskQueue: DispatchQueue = DispatchQueue(label: "Scheduler Task Queue", qos: .background)
     
     
     /// Creates a new ``Scheduler`` module.
@@ -68,36 +69,33 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     }
     
     
+    public func requestLocalNotificationAuthorization() async throws {
+        if await UNUserNotificationCenter.current().notificationSettings().authorizationStatus != .authorized {
+            try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+        }
+        
+        taskQueue.async {
+            for task in self.tasks {
+                task.scheduleTaskAndNotification()
+            }
+        }
+    }
+    
+    
     /// Schedule a new ``Task`` in the ``Scheduler`` module.
     /// - Parameter task: The new ``Task`` instance that should be scheduled.
     public func schedule(task: Task<Context>) {
-        DispatchQueue(label: "Scheduler Task Queue", qos: .background).async {
-            let futureEvents = task.events(from: .now.addingTimeInterval(-1), to: .endDate(.distantFuture))
-            self.timers.reserveCapacity(self.timers.count + futureEvents.count)
-            
-            for futureEvent in futureEvents {
-                let scheduledTimer = Timer(
-                    timeInterval: max(Date.now.distance(to: futureEvent.scheduledAt), 0.01),
-                    repeats: false,
-                    block: { timer in
-                        timer.invalidate()
-                        task.objectWillChange.send()
-                    }
-                )
-                
-                RunLoop.current.add(scheduledTimer, forMode: .common)
-                self.timers.append(scheduledTimer)
-            }
-            
-            RunLoop.current.run()
-        }
-        
         task.objectWillChange
             .receive(on: RunLoop.main)
             .sink {
                 self.objectWillChange.send()
             }
             .store(in: &cancellables)
+        
+        taskQueue.async {
+            task.scheduleTaskAndNotification()
+            RunLoop.current.run()
+        }
         
         tasks.append(task)
     }
@@ -119,9 +117,6 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     
     
     deinit {
-        for timer in timers where timer.isValid {
-            timer.invalidate()
-        }
         for cancellable in cancellables {
             cancellable.cancel()
         }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -8,9 +8,9 @@
 
 import Combine
 import Foundation
-import UserNotifications
 import Spezi
 import SpeziLocalStorage
+import UserNotifications
 
 
 /// The ``Scheduler/Scheduler`` module allows the scheduling and observation of ``Task``s adhering to a specific ``Schedule``.
@@ -24,7 +24,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     public private(set) var tasks: [Task<Context>] = []
     private var initialTasks: [Task<Context>]
     private var cancellables: Set<AnyCancellable> = []
-    private let taskQueue: DispatchQueue = DispatchQueue(label: "Scheduler Task Queue", qos: .background)
+    private let taskQueue = DispatchQueue(label: "Scheduler Task Queue", qos: .background)
     
     
     /// Creates a new ``Scheduler`` module.

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -126,7 +126,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
             }
             
             // If there is a maximum number of elements and we are past that point we can return and end the appending of sorted events.
-            if let maxNumberOfEvents = end?.numberOfEvents, filteredEvents.count > maxNumberOfEvents {
+            if let maxNumberOfEvents = end?.numberOfEvents, filteredEvents.count >= maxNumberOfEvents {
                 break
             }
             
@@ -138,7 +138,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
             filteredEvents.append(event)
         }
         
-        return sortedEvents
+        return filteredEvents
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -51,6 +51,8 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     ///   - notifications: Determines of the task should register local notifications to remind the user to fulfill the task.
     ///   - context: The customized context of the ``Task``.
     public init(
+        // swiftlint:disable:previous function_default_parameter_at_end
+        // The notification paramter is the last parameter excluding the user Context attached to a task.
         title: String,
         description: String,
         schedule: Schedule,

--- a/Sources/SpeziScheduler/TaskReference.swift
+++ b/Sources/SpeziScheduler/TaskReference.swift
@@ -9,13 +9,12 @@
 import Foundation
 
 
-protocol TaskReference: AnyObject, ObservableObject {
+protocol TaskReference: AnyObject {
     var id: UUID { get }
     var title: String { get }
     var description: String { get }
     var schedule: Schedule { get }
     var notifications: Bool { get }
-    var completedEvents: [Date: Event] { get set }
     
     
     func sendObjectWillChange()

--- a/Sources/SpeziScheduler/TaskReference.swift
+++ b/Sources/SpeziScheduler/TaskReference.swift
@@ -9,8 +9,14 @@
 import Foundation
 
 
-protocol EventContext: AnyObject {
+protocol TaskReference: AnyObject, ObservableObject {
     var id: UUID { get }
+    var title: String { get }
+    var description: String { get }
     var schedule: Schedule { get }
+    var notifications: Bool { get }
     var completedEvents: [Date: Event] { get set }
+    
+    
+    func sendObjectWillChange()
 }

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -92,7 +92,7 @@ final class SchedulerTests: XCTestCase {
         let scheduler = createScheduler(withInitialTasks: testTask)
         
         let expectation = XCTestExpectation(description: "Get Updates for all scheduled events.")
-        expectation.expectedFulfillmentCount = numberOfEvents + 1
+        expectation.expectedFulfillmentCount = numberOfEvents
         expectation.assertForOverFulfill = true
         
         let cancellable = scheduler.objectWillChange.sink {
@@ -236,7 +236,8 @@ final class SchedulerTests: XCTestCase {
     func testCurrentCalendarEncoding() throws {
         let json = """
         {
-            "completedEvents": [],
+            "events": [],
+            "notifications": false,
             "context": "This is a test context",
             "description": "This is a test task",
             "id": "DEDDE3FF-0A75-4A8C-9F0D-75AD417F1104",

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -38,6 +38,11 @@ struct ContentView: View {
         Text("\(tasks) Tasks")
         Text("\(events) Events")
         Text("Fulfilled \(fulfilledEvents) Events")
+        Button("Request Notification Permissions") {
+            _Concurrency.Task {
+                try await scheduler.requestLocalNotificationAuthorization()
+            }
+        }
         Button("Add Task") {
             scheduler.schedule(
                 task: Task(
@@ -48,6 +53,21 @@ struct ContentView: View {
                         repetition: .matching(.init(nanosecond: 0)), // Every full second
                         end: .numberOfEvents(2)
                     ),
+                    context: "New Task!"
+                )
+            )
+        }
+        Button("Add Notification Task") {
+            scheduler.schedule(
+                task: Task(
+                    title: "New Task",
+                    description: "New Task",
+                    schedule: Schedule(
+                        start: .now,
+                        repetition: .matching(.init(nanosecond: 0)), // Every full second
+                        end: .numberOfEvents(2)
+                    ),
+                    notifications: true,
                     context: "New Task!"
                 )
             )

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -62,7 +62,7 @@ class TestAppUITests: XCTestCase {
         app.buttons["Unfulfull Event"].tap()
         app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
         
-        app.buttons["Add Task"].tap()
+        app.buttons["Add Notification Task"].tap()
         app.assert(tasks: 3, events: 5, fulfilledEvents: 2)
         
         app.buttons["Fulfill Event"].tap()


### PR DESCRIPTION
# Add Support for Local Notifications

## :recycle: Current situation & Problem
- Tasks are currently surfaced in the application but do not tigger a local notification that would remind a user to complete a task at the time the task should be scheduled.

## :bulb: Proposed solution
- Adds the `notifications` parameter to the `Task` type that configures if a local notification should be emitted.
- Local notifications are only emitted after the user has given permission. The method `requestLocalNotificationAuthorization()` on the `Scheduler` type can be used to get permission to send out notifications, e.g., during the onboarding flow.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
