### PR TITLE
Fix Notification Scheduling and Scheduler Refreshing

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -21,7 +21,7 @@ import UserNotifications
 public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable, Module {
     @Dependency private var localStorage: LocalStorage
     
-    public private(set) var tasks: [Task<Context>] = []
+    @Published public private(set) var tasks: [Task<Context>] = []
     private var initialTasks: [Task<Context>]
     private var cancellables: Set<AnyCancellable> = []
     private let taskQueue = DispatchQueue(label: "Scheduler Task Queue", qos: .background)

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -24,6 +24,12 @@ struct ContentView: View {
             .count
     }
     
+    private var pastEvents: Int {
+        scheduler.tasks
+            .flatMap { $0.events(to: .endDate(.now)) }
+            .count
+    }
+    
     private var fulfilledEvents: Int {
         scheduler.tasks
             .flatMap { $0.events() }
@@ -37,6 +43,7 @@ struct ContentView: View {
             .font(.headline)
         Text("\(tasks) Tasks")
         Text("\(events) Events")
+        Text("\(pastEvents) Past Events")
         Text("Fulfilled \(fulfilledEvents) Events")
         Button("Request Notification Permissions") {
             _Concurrency.Task {
@@ -66,15 +73,15 @@ struct ContentView: View {
             
             scheduler.schedule(
                 task: Task(
-                    title: "New Task",
-                    description: "New Task",
+                    title: "Notification Task",
+                    description: "Notification Task",
                     schedule: Schedule(
                         start: .now,
                         repetition: .matching(.init(hour: hour, minute: minute)),
-                        end: .numberOfEvents(2)
+                        end: .numberOfEvents(1)
                     ),
                     notifications: true,
-                    context: "New Task!"
+                    context: "Notification Task!"
                 )
             )
         }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -58,13 +58,19 @@ struct ContentView: View {
             )
         }
         Button("Add Notification Task") {
+            let currentDate = Date.now
+            let hour = Calendar.current.component(.hour, from: currentDate)
+            // We expect the UI test to take at least 20 seconds to mavigate out of the app and to the home screen.
+            // We then trigger the task in the minute after that, the UI test needs to wait at least one minute.
+            let minute = Calendar.current.component(.minute, from: currentDate.addingTimeInterval(20)) + 1
+            
             scheduler.schedule(
                 task: Task(
                     title: "New Task",
                     description: "New Task",
                     schedule: Schedule(
                         start: .now,
-                        repetition: .matching(.init(nanosecond: 0)), // Every full second
+                        repetition: .matching(.init(hour: hour, minute: minute)),
                         end: .numberOfEvents(2)
                     ),
                     notifications: true,

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -113,6 +113,7 @@ class TestAppUITests: XCTestCase {
 
 
 extension XCUIApplication {
+    // swiftlint:disable:next function_default_parameter_at_end
     fileprivate func assert(tasks: Int, events: Int, pastEvents: Int? = nil, fulfilledEvents: Int) {
         XCTAssert(staticTexts["\(tasks) Tasks"].waitForExistence(timeout: 2))
         XCTAssert(staticTexts["\(events) Events"].waitForExistence(timeout: 2))

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -26,13 +26,13 @@ class TestAppUITests: XCTestCase {
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         
-        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        app.assert(tasks: 1, events: 1, pastEvents: 1, fulfilledEvents: 0)
         
         app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 1, events: 1, fulfilledEvents: 1)
+        app.assert(tasks: 1, events: 1, pastEvents: 1, fulfilledEvents: 1)
         
         app.buttons["Unfulfull Event"].tap()
-        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        app.assert(tasks: 1, events: 1, pastEvents: 1, fulfilledEvents: 0)
         
         app.buttons["Add Task"].tap()
         app.assert(tasks: 2, events: 3, fulfilledEvents: 0)
@@ -41,40 +41,35 @@ class TestAppUITests: XCTestCase {
         app.buttons["Fulfill Event"].tap()
         app.buttons["Fulfill Event"].tap()
         app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 2, events: 3, fulfilledEvents: 3)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 3)
         
         
         app.terminate()
         app.launch()
         
-        app.assert(tasks: 2, events: 3, fulfilledEvents: 3)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 3)
         
         app.buttons["Unfulfull Event"].tap()
-        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 2)
         
         
         app.terminate()
         app.launch()
         
-        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 2)
         
         app.buttons["Fulfill Event"].tap()
         app.buttons["Unfulfull Event"].tap()
-        app.assert(tasks: 2, events: 3, fulfilledEvents: 2)
-        
-        app.buttons["Add Notification Task"].tap()
-        app.assert(tasks: 3, events: 5, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 2)
         
         app.buttons["Fulfill Event"].tap()
-        app.buttons["Fulfill Event"].tap()
-        app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 3, events: 5, fulfilledEvents: 5)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 3)
         
         
         app.terminate()
         app.launch()
         
-        app.assert(tasks: 3, events: 5, fulfilledEvents: 5)
+        app.assert(tasks: 2, events: 3, pastEvents: 3, fulfilledEvents: 3)
     }
     
     
@@ -83,35 +78,47 @@ class TestAppUITests: XCTestCase {
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         
-        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        app.assert(tasks: 1, events: 1, pastEvents: 1, fulfilledEvents: 0)
         
-        app.buttons["Add Notification Task"].tap()
-        app.assert(tasks: 2, events: 1, fulfilledEvents: 0)
+        app.buttons["Request Notification Permissions"].tap()
         
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let alertAllowButton = springboard.buttons["Allow"]
+        if alertAllowButton.waitForExistence(timeout: 5) {
+            alertAllowButton.tap()
+        } else {
+            print("Did not observe the notification permissions alert. Permissions might have already been provided.")
+        }
+        
+        app.buttons["Add Notification Task"].tap()
+        app.assert(tasks: 2, events: 2, pastEvents: 1, fulfilledEvents: 0)
+        
         springboard.activate()
         XCTAssert(springboard.wait(for: .runningForeground, timeout: 2))
         
-        let notification = springboard.otherElements["NotificationShortLookView"]
+        let notification = springboard.otherElements["Notification"].descendants(matching: .any)["NotificationShortLookView"]
         XCTAssert(notification.waitForExistence(timeout: 120))
         notification.tap()
         
         XCTAssert(app.wait(for: .runningForeground, timeout: 2))
         
-        app.assert(tasks: 2, events: 2, fulfilledEvents: 0)
+        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 0)
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         app.buttons["Fulfill Event"].tap()
         app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 2, events: 2, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 2)
     }
 }
 
 
 extension XCUIApplication {
-    fileprivate func assert(tasks: Int, events: Int, fulfilledEvents: Int) {
+    fileprivate func assert(tasks: Int, events: Int, pastEvents: Int? = nil, fulfilledEvents: Int) {
         XCTAssert(staticTexts["\(tasks) Tasks"].waitForExistence(timeout: 2))
         XCTAssert(staticTexts["\(events) Events"].waitForExistence(timeout: 2))
+        if let pastEvents {
+            XCTAssert(staticTexts["\(pastEvents) Past Events"].waitForExistence(timeout: 2))
+        }
         XCTAssert(staticTexts["Fulfilled \(fulfilledEvents) Events"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -76,6 +76,35 @@ class TestAppUITests: XCTestCase {
         
         app.assert(tasks: 3, events: 5, fulfilledEvents: 5)
     }
+    
+    
+    func testSchedulerNotifications() throws {
+        let app = XCUIApplication()
+        
+        XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
+        
+        app.assert(tasks: 1, events: 1, fulfilledEvents: 0)
+        
+        app.buttons["Add Notification Task"].tap()
+        app.assert(tasks: 2, events: 1, fulfilledEvents: 0)
+        
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        springboard.activate()
+        XCTAssert(springboard.wait(for: .runningForeground, timeout: 2))
+        
+        let notification = springboard.otherElements["NotificationShortLookView"]
+        XCTAssert(notification.waitForExistence(timeout: 120))
+        notification.tap()
+        
+        XCTAssert(app.wait(for: .runningForeground, timeout: 2))
+        
+        app.assert(tasks: 2, events: 2, fulfilledEvents: 0)
+        
+        XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
+        app.buttons["Fulfill Event"].tap()
+        app.buttons["Fulfill Event"].tap()
+        app.assert(tasks: 2, events: 2, fulfilledEvents: 2)
+    }
 }
 
 

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -622,7 +622,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.1;
+				minimumVersion = 0.4.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
# Fix Notification Scheduling and Scheduler Refreshing

## : bulb: Current situation & Proposed solution
- Addresses and issue where the notifications were not properly scheduled when tasks were added after the initial scheduler was created
- Fixes the issue where the scheduler did not refresh a SwiftUI view when a new task was added.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
