### PR TITLE
Improve Notification Scheduling and Task Management

### DIFF
--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -25,7 +25,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     
     
     private let lock = Lock()
-    private let timer: Timer? = nil
+    private var timer: Timer?
     private let _scheduledAt: Date
     private var notification: UUID?
     /// The date when the ``Event`` was completed.
@@ -73,7 +73,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         
         // Schedule the timer for the event that refreshes the Observable Object.
         if timer == nil {
-            let scheduledTimer = Timer(
+            timer = Timer(
                 timeInterval: max(Date.now.distance(to: scheduledAt), 0.01),
                 repeats: false,
                 block: { timer in
@@ -82,7 +82,9 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                 }
             )
             
-            RunLoop.main.add(scheduledTimer, forMode: .common)
+            if let timer {
+                RunLoop.main.add(timer, forMode: .common)
+            }
         }
         
         // Only schedule a notification if it is enabled in a task and the notification has not yet been scheduled.

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -82,7 +82,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                 }
             )
             
-            RunLoop.current.add(scheduledTimer, forMode: .common)
+            RunLoop.main.add(scheduledTimer, forMode: .common)
         }
         
         // Only schedule a notification if it is enabled in a task and the notification has not yet been scheduled.

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -113,7 +113,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     
     private func updateScheduleTaskAndNotifications() {
         let numberOfTasksWithNotifications = max(tasks.filter(\.notifications).count, 1)
-        let prescheduleLimit = 64/numberOfTasksWithNotifications
+        let prescheduleLimit = 64 / numberOfTasksWithNotifications
         
         for task in self.tasks {
             task.scheduleTaskAndNotification(prescheduleLimit)

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -112,7 +112,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     }
     
     private func updateScheduleTaskAndNotifications() {
-        let numberOfTasksWithNotifications = tasks.filter(\.notifications).count
+        let numberOfTasksWithNotifications = max(tasks.filter(\.notifications).count, 1)
         let prescheduleLimit = 64/numberOfTasksWithNotifications
         
         for task in self.tasks {

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -24,7 +24,6 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
     @Published public private(set) var tasks: [Task<Context>] = []
     private var initialTasks: [Task<Context>]
     private var cancellables: Set<AnyCancellable> = []
-    private let taskQueue = DispatchQueue(label: "Scheduler Task Queue", qos: .background)
     
     
     /// Creates a new ``Scheduler`` module.
@@ -74,10 +73,8 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
             try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
         }
         
-        taskQueue.async {
-            for task in self.tasks {
-                task.scheduleTaskAndNotification()
-            }
+        for task in self.tasks {
+            task.scheduleTaskAndNotification()
         }
     }
     
@@ -92,10 +89,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: Equatable
             }
             .store(in: &cancellables)
         
-        taskQueue.async {
-            task.scheduleTaskAndNotification()
-            RunLoop.current.run()
-        }
+        task.scheduleTaskAndNotification()
         
         tasks.append(task)
     }

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -97,8 +97,9 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     }
     
     
-    func scheduleTaskAndNotification() {
-        let futureEvents = events(from: .now.addingTimeInterval(-1), to: .endDate(.distantFuture))
+    func scheduleTaskAndNotification(_ prescheduleLimit: Int = 16) {
+        // We only schedule the next few events as iOS only allows up to 64 notifications to be scheduled per one app.
+        let futureEvents = events(from: .now.addingTimeInterval(-1), to: .numberOfEvents(prescheduleLimit))
         
         for futureEvent in futureEvents {
             futureEvent.scheduleTaskAndNotification()

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -132,7 +132,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
             }
             
             // We exit the loop if we are past the end date
-            if let endDate = end?.endDate, event.scheduledAt > endDate {
+            if let endDate = end?.endDate, event.scheduledAt >= endDate {
                 break
             }
             

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -71,6 +71,8 @@ struct ContentView: View {
             // We then trigger the task in the minute after that, the UI test needs to wait at least one minute.
             let minute = Calendar.current.component(.minute, from: currentDate.addingTimeInterval(20)) + 1
             
+            // We schedule 128 notifications to test that the schedule limit to 64 notifications per device is enforced
+            // and notifications show on the device (iOS only limits up to 64 scheduled local notifications.
             scheduler.schedule(
                 task: Task(
                     title: "Notification Task",
@@ -78,7 +80,7 @@ struct ContentView: View {
                     schedule: Schedule(
                         start: .now,
                         repetition: .matching(.init(hour: hour, minute: minute)),
-                        end: .numberOfEvents(1)
+                        end: .numberOfEvents(128)
                     ),
                     notifications: true,
                     context: "Notification Task!"

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -23,11 +23,9 @@ class TestAppDelegate: SpeziAppDelegate {
                         description: "Original Task",
                         schedule: Schedule(
                             start: .now,
-                            repetition: .matching(.init(hour: 14, minute: 11)),
-                            // repetition: .matching(.init(nanosecond: 0)), // Every full second
-                            end: .numberOfEvents(356)
+                            repetition: .matching(.init(nanosecond: 0)), // Every full second
+                            end: .numberOfEvents(1)
                         ),
-                        notifications: true,
                         context: "Original Task!"
                     )
                 ]

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -23,9 +23,11 @@ class TestAppDelegate: SpeziAppDelegate {
                         description: "Original Task",
                         schedule: Schedule(
                             start: .now,
-                            repetition: .matching(.init(nanosecond: 0)), // Every full second
-                            end: .numberOfEvents(1)
+                            repetition: .matching(.init(hour: 14, minute: 11)),
+                            // repetition: .matching(.init(nanosecond: 0)), // Every full second
+                            end: .numberOfEvents(356)
                         ),
+                        notifications: true,
                         context: "Original Task!"
                     )
                 ]

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -83,16 +83,16 @@ class TestAppUITests: XCTestCase {
         app.requestNotificationPermissions()
         
         app.buttons["Add Notification Task"].tap()
-        app.assert(tasks: 2, events: 2, pastEvents: 1, fulfilledEvents: 0)
+        app.assert(tasks: 2, events: 129, pastEvents: 1, fulfilledEvents: 0)
         
         app.findAndTapNotification()
         
-        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 0)
+        app.assert(tasks: 2, events: 129, pastEvents: 2, fulfilledEvents: 0)
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         app.buttons["Fulfill Event"].tap()
         app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 129, pastEvents: 2, fulfilledEvents: 2)
     }
     
     func testSchedulerNotificationsBeforePermissions() throws {
@@ -103,7 +103,7 @@ class TestAppUITests: XCTestCase {
         app.assert(tasks: 1, events: 1, pastEvents: 1, fulfilledEvents: 0)
         
         app.buttons["Add Notification Task"].tap()
-        app.assert(tasks: 2, events: 2, pastEvents: 1, fulfilledEvents: 0)
+        app.assert(tasks: 2, events: 129, pastEvents: 1, fulfilledEvents: 0)
         
         app.requestNotificationPermissions()
         
@@ -114,7 +114,7 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         app.buttons["Fulfill Event"].tap()
         app.buttons["Fulfill Event"].tap()
-        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 2)
+        app.assert(tasks: 2, events: 129, pastEvents: 2, fulfilledEvents: 2)
     }
 }
 

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -109,7 +109,7 @@ class TestAppUITests: XCTestCase {
         
         app.findAndTapNotification()
         
-        app.assert(tasks: 2, events: 2, pastEvents: 2, fulfilledEvents: 0)
+        app.assert(tasks: 2, events: 129, pastEvents: 2, fulfilledEvents: 0)
         
         XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
         app.buttons["Fulfill Event"].tap()


### PR DESCRIPTION
# Improve Notification Scheduling and Task Management

## :recycle: Current situation & Problem
- Notifications are not triggered when permissions are given after a task has been scheduled.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
