### PR TITLE
Flag that indicates if Local Notification authorization given

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,8 +10,6 @@
 only_rules:
   # All Images that provide context should have an accessibility label. Purely decorative images can be hidden from accessibility.
   - accessibility_label_for_image
-  # Attributes should be on their own lines in functions and types, but on the same line as variables and imports.
-  - attributes
   # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
   - array_init
   # Prefer the new block based KVO API with keypaths when using Swift 3.2 or later.

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -26,6 +26,12 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: NSObject,
     private var initialTasks: [Task<Context>]
     private var cancellables: Set<AnyCancellable> = []
     
+    /// Indicates whether the necessary authorization to deliver local notifications is already granted.
+    public var localNotificationAuthorization: Bool {
+        get async {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus == .authorized
+        }
+    }
     
     /// Creates a new ``Scheduler`` module.
     /// - Parameter tasks: The initial set of ``Task``s.
@@ -69,7 +75,7 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: NSObject,
     
     /// Presents the system authentication UI to send local notifications if the application is not yet permitted to send local notifications.
     public func requestLocalNotificationAuthorization() async throws {
-        if await UNUserNotificationCenter.current().notificationSettings().authorizationStatus != .authorized {
+        if await !localNotificationAuthorization {
             try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
         }
         

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -77,6 +77,8 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: NSObject,
     public func requestLocalNotificationAuthorization() async throws {
         if await !localNotificationAuthorization {
             try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+            // Triggers an update of the UI in case the notification permissions are changed
+            self.objectWillChange.send()
         }
         
         updateScheduleTaskAndNotifications()

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject private var scheduler: TestAppScheduler
-    @State private var notificationAuthorizationGranted: Bool = false
+    @State private var notificationAuthorizationGranted = false
     
     
     private var tasks: Int {

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject private var scheduler: TestAppScheduler
+    @State private var notificationAuthorizationGranted: Bool = false
     
     
     private var tasks: Int {
@@ -48,8 +49,10 @@ struct ContentView: View {
         Button("Request Notification Permissions") {
             _Concurrency.Task {
                 try await scheduler.requestLocalNotificationAuthorization()
+                notificationAuthorizationGranted = await scheduler.localNotificationAuthorization
             }
         }
+        .disabled(notificationAuthorizationGranted)
         Button("Add Task") {
             scheduler.schedule(
                 task: Task(

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 @main
 struct UITestsApp: App {
-    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate // swiftlint:disable:this attributes
+    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate
     
     
     var body: some Scene {

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 @main
 struct UITestsApp: App {
-    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate
+    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate // swiftlint:disable:this attributes
     
     
     var body: some Scene {

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -112,6 +112,27 @@ class TestAppUITests: XCTestCase {
         app.buttons["Fulfill Event"].tap()
         app.assert(tasks: 2, events: 129, pastEvents: 2, fulfilledEvents: 2)
     }
+    
+    func testRepeatedNotificationAuthorization() throws {
+        let app = XCUIApplication()
+        
+        XCTAssert(app.staticTexts["Scheduler"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["Request Notification Permissions"].isEnabled)
+        
+        app.requestNotificationPermissions()
+        
+        // Wait for button to become disabled
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                !app.buttons["Request Notification Permissions"].isEnabled
+            },
+            object: .none
+        )
+
+        wait(for: [expectation], timeout: 2)
+        
+        XCTAssert(!app.buttons["Request Notification Permissions"].isEnabled)
+    }
 }
 
 

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.4;
+				minimumVersion = 0.4.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Flag that indicates if Local Notification authorization given

## :recycle: Current situation & Problem
As an application developer utilizing the `Spezi` framework, there is currently no way to determine if the Local Notification authorizations are already granted. This could result in unnecessary onboarding views to grant notification permissions, even though they are already given.

## :bulb: Proposed solution
The `Scheduler` module is extended by the `public var localNotificationAuthorization: Bool` flag. This property indicates whether the authorization to deliver local notifications is already given to the app. Note that the flag is an `async get` computed property, meaning one has to `await` the result.

An example usage could be the following:
```swift
struct HealthKitPermissions: View {
    @EnvironmentObject var scheduler: Scheduler<FHIR, SomeContext>

    var body: some View {
        OnboardingView(
            ...,
            action: {
                if await !scheduler.localNotificationAuthorization {
                    ...
                }
        )
    }
}
```

## :gear: Release Notes 
- Extend the public API of the `Scheduler` module by a flag that allows to determine if the authorizations to deliver notifications are already granted

## :heavy_plus_sign: Additional Information
--

### Related PRs
[SpeziTemplateApplication PR](https://github.com/StanfordSpezi/SpeziTemplateApplication/pull/26)

### Testing
A UI test case was written to check the behavior of the flag.

### Reviewer Nudging
Code changes are minimal

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
