### PR TITLE
Publish rerender event on the main UI thread

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -77,8 +77,11 @@ public class Scheduler<ComponentStandard: Standard, Context: Codable>: NSObject,
     public func requestLocalNotificationAuthorization() async throws {
         if await !localNotificationAuthorization {
             try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
+            
             // Triggers an update of the UI in case the notification permissions are changed
-            self.objectWillChange.send()
+            _Concurrency.Task { @MainActor in
+                self.objectWillChange.send()
+            }
         }
         
         updateScheduleTaskAndNotifications()


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Publish rerender event on the main UI thread

## :recycle: Current situation & Problem
Currently, we publish an `objectWillChange` event that triggers a rerendering of the associated view not on the main UI thread (so the `@MainActor`). 

## :bulb: Proposed solution
Publish the event on the main UI thread via `@MainActor`.

## :gear: Release Notes 
- Small fix to publish `objectWillChange` event on main UI thread

## :heavy_plus_sign: Additional Information
--

### Related PRs
- #14

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
