### PR TITLE
Improve Notification Handling & Storage of State Information

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,12 +16,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build Swift Package on Xcode 14
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macos-13"]'
-      scheme: SpeziScheduler
   buildandtest:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -33,7 +27,6 @@ jobs:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    name: Build Swift Package on Xcode 14
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      scheme: SpeziScheduler
+      test: false
   buildandtest:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    name: Build Swift Package on Xcode 14
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macos-13"]'
+      scheme: SpeziScheduler
   buildandtest:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,7 @@ jobs:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      xcodeversion: latest
       artifactname: SpeziScheduler.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziScheduler
@@ -27,6 +28,7 @@ jobs:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
+      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,17 +23,10 @@ jobs:
       artifactname: SpeziScheduler.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziScheduler
-  build:
-    name: Build Swift Package on Xcode 14
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macos-13"]'
-      scheme: SpeziScheduler
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      xcodeversion: latest
       artifactname: TestApp.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -377,8 +377,8 @@ deployment_target: # Availability checks or attributes shouldn’t be using olde
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - .build
   - .swiftpm
-  - .deriveddata
-  - Tests/UITests/.deriveddata
+  - .derivedData
+  - Tests/UITests/.derivedData
 
 closure_body_length: # Closure bodies should not span too many lines.
   - 35 # warning - default: 20

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OSLog
 import UserNotifications
 
 
@@ -27,9 +28,17 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     private let lock = Lock()
     private var timer: Timer?
     private let _scheduledAt: Date
-    private var notification: UUID?
+    private var notification: UUID? {
+        willSet {
+            taskReference?.sendObjectWillChange()
+        }
+    }
     /// The date when the ``Event`` was completed.
-    public private(set) var completedAt: Date?
+    public private(set) var completedAt: Date? {
+        willSet {
+            taskReference?.sendObjectWillChange()
+        }
+    }
     weak var taskReference: (any TaskReference)?
     
     
@@ -109,7 +118,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                     
                     notificationCenter.add(request) { error in
                         if let error {
-                            print("Could not schedule task as local notification: \(error)")
+                            os_log(.error, "Could not schedule task as local notification: \(error)")
                             return
                         }
                         
@@ -140,8 +149,6 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             } else {
                 completedAt = nil
             }
-            
-            taskReference?.sendObjectWillChange()
         }
     }
     

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -77,6 +77,34 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     }
     
     
+    /// Use this function to mark an ``Event`` as complete or incomplete.
+    /// - Parameter newValue: The new state of the ``Event``.
+    public func complete(_ newValue: Bool) async {
+        await lock.enter {
+            if newValue {
+                completedAt = Date()
+                if let notification {
+                    let notificationCenter = UNUserNotificationCenter.current()
+                    notificationCenter.removeDeliveredNotifications(withIdentifiers: [notification.uuidString])
+                    notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
+                }
+            } else {
+                completedAt = nil
+            }
+        }
+    }
+    
+    /// Toggle the ``Event``'s ``Event/complete`` state.
+    public func toggle() async {
+        await complete(!complete)
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(taskReference?.id)
+        hasher.combine(_scheduledAt)
+    }
+    
+    
     func cancelNotification() {
         guard let notification else {
             return
@@ -152,35 +180,6 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                 }
             }
         }
-    }
-    
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(taskReference?.id)
-        hasher.combine(_scheduledAt)
-    }
-    
-    /// Use this function to mark an ``Event`` as complete or incomplete.
-    /// - Parameter newValue: The new state of the ``Event``.
-    public func complete(_ newValue: Bool) async {
-        await lock.enter {
-            if newValue {
-                completedAt = Date()
-                if let notification {
-                    let notificationCenter = UNUserNotificationCenter.current()
-                    notificationCenter.removeDeliveredNotifications(withIdentifiers: [notification.uuidString])
-                    notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
-                }
-            } else {
-                completedAt = nil
-            }
-        }
-    }
-    
-    
-    /// Toggle the ``Event``'s ``Event/complete`` state.
-    public func toggle() async {
-        await complete(!complete)
     }
     
     

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -86,7 +86,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         self.notification = nil
     }
     
-    func scheduleTaskAndNotification() {
+    func scheduleTask() {
         guard let taskReference = taskReference else {
             return
         }
@@ -105,6 +105,12 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             if let timer {
                 RunLoop.main.add(timer, forMode: .common)
             }
+        }
+    }
+    
+    func scheduleNotification() {
+        guard let taskReference = taskReference else {
+            return
         }
         
         // Only schedule a notification if it is enabled in a task and the notification has not yet been scheduled.

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -83,6 +83,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         }
         
         let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.removeDeliveredNotifications(withIdentifiers: [notification.uuidString])
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
         
         self.notification = nil
@@ -97,7 +98,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         // Schedule the timer for the event that refreshes the Observable Object.
         if timer == nil {
             timer = Timer(
-                timeInterval: max(Date.now.distance(to: scheduledAt), 0.01),
+                timeInterval: max(Date.now.distance(to: scheduledAt), .leastNonzeroMagnitude),
                 repeats: false,
                 block: { timer in
                     timer.invalidate()
@@ -141,7 +142,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                     self.log = "Registered at \(self.scheduledAt.timeIntervalSince(.now))"
                     self.notification = identifier
                 } catch {
-                    os_log(.error, "Could not schedule task as local notification: \(error)")
+                    os_log(.error, "Spezi.Scheduler: Could not schedule task as local notification: \(error)")
                     self.log = "Could not schedule task as local notification: \(error)"
                 }
             }

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -39,7 +39,8 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             taskReference?.sendObjectWillChange()
         }
     }
-    public var log: String?
+    /// Only used for test purposes to identify the current state of the log in the UI testing application.
+    internal private(set) var log: String?
     weak var taskReference: (any TaskReference)?
     
     
@@ -85,6 +86,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
         
         self.notification = nil
+        self.log = "No Notification - Complete: \(complete)"
     }
     
     func scheduleTask() {
@@ -119,6 +121,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             let notificationCenter = UNUserNotificationCenter.current()
             switch await notificationCenter.notificationSettings().authorizationStatus {
             case .notDetermined, .denied:
+                self.log = "Could not register due to missing permissions ..."
                 return
             default:
                 let content = UNMutableNotificationContent()

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -82,6 +82,11 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
             return
         }
         
+        guard complete || scheduledAt > .now else {
+            self.log = "Notification Delivered - Not yet Completed"
+            return
+        }
+        
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.removeDeliveredNotifications(withIdentifiers: [notification.uuidString])
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
@@ -139,7 +144,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
                 
                 do {
                     try await notificationCenter.add(request)
-                    self.log = "Registered at \(self.scheduledAt.timeIntervalSince(.now))"
+                    self.log = "Registered at \(self.scheduledAt.formatted(date: .abbreviated, time: .complete))"
                     self.notification = identifier
                 } catch {
                     os_log(.error, "Spezi.Scheduler: Could not schedule task as local notification: \(error)")

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -28,14 +28,14 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     private let lock = Lock()
     private var timer: Timer?
     private let _scheduledAt: Date
-    private(set) var notification: UUID? {
-        willSet {
-            taskReference?.sendObjectWillChange()
-        }
-    }
+    private(set) var notification: UUID?
     /// The date when the ``Event`` was completed.
     public private(set) var completedAt: Date? {
-        willSet {
+        didSet {
+            guard completedAt != oldValue else {
+                return
+            }
+            
             taskReference?.sendObjectWillChange()
         }
     }

--- a/Sources/SpeziScheduler/Event.swift
+++ b/Sources/SpeziScheduler/Event.swift
@@ -28,7 +28,7 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
     private let lock = Lock()
     private var timer: Timer?
     private let _scheduledAt: Date
-    private var notification: UUID? {
+    private(set) var notification: UUID? {
         willSet {
             taskReference?.sendObjectWillChange()
         }
@@ -74,6 +74,17 @@ public final class Event: Codable, Identifiable, Hashable, @unchecked Sendable {
         lhs.taskReference?.id == rhs.taskReference?.id && lhs.scheduledAt == rhs.scheduledAt
     }
     
+    
+    func cancelNotification() {
+        guard let notification else {
+            return
+        }
+        
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
+        
+        self.notification = nil
+    }
     
     func scheduleTaskAndNotification() {
         guard let taskReference = taskReference else {

--- a/Sources/SpeziScheduler/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule.swift
@@ -210,7 +210,7 @@ public class Schedule: Codable, @unchecked Sendable, ObservableObject {
         }
         
         if randomDisplacementChanged {
-            objectWillChange.send()
+            self.objectWillChange.send()
         }
         
         return dates

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -140,7 +140,6 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     /// - Parameter task: The new ``Task`` instance that should be scheduled.
     public func schedule(task: Task<Context>) async {
         task.objectWillChange
-            .receive(on: RunLoop.main)
             .sink {
                 self.sendObjectWillChange()
             }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import OSLog
 import Spezi
 import SpeziLocalStorage
 import UIKit
@@ -49,12 +50,13 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
         )
         
         self.objectWillChange
+            .throttle(for: .seconds(0.25), scheduler: RunLoop.main, latest: true)
             .sink {
                 _Concurrency.Task {
                     do {
                         try self.localStorage.store(self.tasks)
                     } catch {
-                        print(error)
+                        os_log(.error, "Could not persist the tasks of the scheduler module: \(error)")
                     }
                 }
             }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -149,7 +149,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
         task.objectWillChange
             .receive(on: RunLoop.main)
             .sink {
-                self.objectWillChange.send()
+                self.sendObjectWillChange()
             }
             .store(in: &cancellables)
         
@@ -166,6 +166,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     }
     
     func sendObjectWillChange() {
+        print("sendObjectWillChange")
         _Concurrency.Task { @MainActor in
             self.objectWillChange.send()
         }

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -120,9 +120,10 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     
     func scheduleNotification(_ prescheduleLimit: Int) async {
         // iOS only allows up to 64 notifications to be scheduled per one app, this is why we have to do the following logic with the prescheduleLimit:
+        // We don't check notifications here in case notifications might becomes mutable in the future.
         
         // Cancel all future notifications to ensure that we only register up to the defined limit.
-        let futureEvents = events(from: .now)
+        let futureEvents = events(from: .now.addingTimeInterval(.leastNonzeroMagnitude))
         
         for futureEvent in futureEvents {
             futureEvent.cancelNotification()

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -110,7 +110,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     
     func scheduleTaskAndNotification(_ prescheduleLimit: Int) {
         // We only schedule the next few events as iOS.
-        let futureEvents = events(from: .now.addingTimeInterval(-1))
+        let futureEvents = events(from: .now)
         
         // iOS only allows up to 64 notifications to be scheduled per one app, this is why we have to do the following logic with the prescheduleLimit:
         

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -38,7 +38,7 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     /// The customized context of the ``Task``.
     public let context: Context
     
-    @Published var events: [Event]
+    private(set) var events: [Event]
     
     private var cancellables: Set<AnyCancellable> = []
     
@@ -125,9 +125,8 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
         }
     }
     
-    
     func sendObjectWillChange() {
-        objectWillChange.send()
+        self.objectWillChange.send()
     }
     
     

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -119,19 +119,19 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
     }
     
     func scheduleNotification(_ prescheduleLimit: Int) async {
-        // We only schedule the future events.
-        let futureEvents = events(from: .now)
-        
         // iOS only allows up to 64 notifications to be scheduled per one app, this is why we have to do the following logic with the prescheduleLimit:
         
         // Cancel all future notifications to ensure that we only register up to the defined limit.
+        let futureEvents = events(from: .now)
+        
         for futureEvent in futureEvents {
             futureEvent.cancelNotification()
         }
         
         if notifications {
+            // We only schedule the future events.
             // Only allows up to 64 notifications to be scheduled per one app, we ensure that we do not exceed the preschedule limit.
-            for futureEvent in futureEvents.sorted(by: { $0.scheduledAt < $1.scheduledAt }).prefix(prescheduleLimit) {
+            for futureEvent in futureEvents.filter({ !$0.complete }).sorted(by: { $0.scheduledAt < $1.scheduledAt }).prefix(prescheduleLimit) {
                 await futureEvent.scheduleNotification()
             }
         }

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -119,9 +119,14 @@ public final class Task<Context: Codable & Sendable>: Codable, Identifiable, Has
             futureEvent.cancelNotification()
         }
         
+        // Set the timers for all events.
+        for futureEvent in futureEvents {
+            futureEvent.scheduleTask()
+        }
+        
         // Only allows up to 64 notifications to be scheduled per one app, we ensure that we do not exceed the preschedule limit.
         for futureEvent in futureEvents.sorted(by: { $0.scheduledAt < $1.scheduledAt }).prefix(prescheduleLimit) {
-            futureEvent.scheduleTaskAndNotification()
+            futureEvent.scheduleNotification()
         }
     }
     

--- a/Sources/SpeziScheduler/Task.swift
+++ b/Sources/SpeziScheduler/Task.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Foundation
+import OSLog
 
 
 /// A ``Task`` defines an instruction that is scheduled one to multiple times as defined by the ``Task/schedule`` property.

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -192,7 +192,7 @@ final class SchedulerTests: XCTestCase {
             }
         }
     
-        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.2) + 1)
+        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.2) + 2)
         cancellable.cancel()
         
         XCTAssert(events.allSatisfy { $0.complete })

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -143,11 +143,12 @@ final class SchedulerTests: XCTestCase {
         scheduler.schedule(task: testTask2)
         
         let expectationCompleteEvents = XCTestExpectation(description: "Complete all events")
-        expectationCompleteEvents.expectedFulfillmentCount = 12
+        expectationCompleteEvents.expectedFulfillmentCount = numberOfEvents * 2
         expectationCompleteEvents.assertForOverFulfill = true
         
         let expectationObservedObject = XCTestExpectation(description: "Get Updates for all scheduled events.")
-        expectationObservedObject.expectedFulfillmentCount = 12
+        // Two times for registering the tasks, each time for an event that is completed.
+        expectationObservedObject.expectedFulfillmentCount = (numberOfEvents * 2) + 2
         expectationObservedObject.assertForOverFulfill = true
         
         let cancellable = scheduler.objectWillChange.sink {

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -187,11 +187,12 @@ final class SchedulerTests: XCTestCase {
         _Concurrency.Task {
             for event in events {
                 await event.complete(true)
+                try? await _Concurrency.Task.sleep(for: .seconds(0.2))
                 expectationCompleteEvents.fulfill()
             }
         }
     
-        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: 1)
+        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.2) + 1)
         cancellable.cancel()
         
         XCTAssert(events.allSatisfy { $0.complete })

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -71,7 +71,7 @@ final class SchedulerTests: XCTestCase {
             test += 1
         }
         
-        wait(for: [expectation], timeout: TimeInterval(numberOfEvents + 2))
+        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 2))
         
         cancellable.cancel()
     }
@@ -116,7 +116,7 @@ final class SchedulerTests: XCTestCase {
             XCTAssertLessThan(nanosecondsElement, 550_000_000)
         }
         
-        wait(for: [expectation], timeout: TimeInterval(numberOfEvents + 2))
+        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 2))
         
         cancellable.cancel()
     }
@@ -155,7 +155,7 @@ final class SchedulerTests: XCTestCase {
         )
         await scheduler.schedule(task: testTask2)
         
-        wait(for: [calledObjectWillChange], timeout: 0.5)
+        await fulfillment(of: [calledObjectWillChange], timeout: 0.5)
         cancellable.cancel()
         
         let expectationCompleteEvents = XCTestExpectation(description: "Complete all events")
@@ -184,7 +184,7 @@ final class SchedulerTests: XCTestCase {
             }
         }
     
-        wait(for: [expectationCompleteEvents, expectationObservedObject], timeout: 100.0)
+        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: 100.0)
         cancellable.cancel()
         
         XCTAssert(events.allSatisfy { $0.complete })

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -140,6 +140,9 @@ final class SchedulerTests: XCTestCase {
         )
         let scheduler = await createScheduler(withInitialTasks: testTask)
         
+        try await _Concurrency.Task.sleep(for: .seconds(1))
+        
+        
         let calledObjectWillChange = XCTestExpectation(description: "Called object will change during registration.")
         calledObjectWillChange.assertForOverFulfill = true
         var cancellable = scheduler.objectWillChange
@@ -187,12 +190,12 @@ final class SchedulerTests: XCTestCase {
         _Concurrency.Task {
             for event in events {
                 await event.complete(true)
-                try? await _Concurrency.Task.sleep(for: .seconds(0.2))
+                try? await _Concurrency.Task.sleep(for: .seconds(0.5))
                 expectationCompleteEvents.fulfill()
             }
         }
     
-        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.2) + 2)
+        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.5) + 3)
         cancellable.cancel()
         
         XCTAssert(events.allSatisfy { $0.complete })

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -71,7 +71,7 @@ final class SchedulerTests: XCTestCase {
             test += 1
         }
         
-        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 2))
+        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 3))
         
         cancellable.cancel()
     }
@@ -116,7 +116,7 @@ final class SchedulerTests: XCTestCase {
             XCTAssertLessThan(nanosecondsElement, 550_000_000)
         }
         
-        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 2))
+        await fulfillment(of: [expectation], timeout: TimeInterval(numberOfEvents + 3))
         
         cancellable.cancel()
     }
@@ -155,7 +155,7 @@ final class SchedulerTests: XCTestCase {
         )
         await scheduler.schedule(task: testTask2)
         
-        await fulfillment(of: [calledObjectWillChange], timeout: 0.5)
+        await fulfillment(of: [calledObjectWillChange], timeout: 1)
         cancellable.cancel()
         
         let expectationCompleteEvents = XCTestExpectation(description: "Complete all events")
@@ -184,7 +184,7 @@ final class SchedulerTests: XCTestCase {
             }
         }
     
-        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: 100.0)
+        await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: 1)
         cancellable.cancel()
         
         XCTAssert(events.allSatisfy { $0.complete })

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -6,12 +6,17 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziScheduler
+@testable import SpeziScheduler
 import SwiftUI
 
 
 struct ContentView: View {
-    struct EventLog: Identifiable {
+    struct EventLog: Identifiable, Comparable {
+        static func < (lhs: ContentView.EventLog, rhs: ContentView.EventLog) -> Bool {
+            lhs.id < rhs.id
+        }
+        
+        
         let id: Date
         let log: String
     }
@@ -54,6 +59,7 @@ struct ContentView: View {
                 
                 return EventLog(id: event.scheduledAt, log: log)
             }
+            .sorted()
     }
     
     
@@ -132,13 +138,10 @@ struct ContentView: View {
                 await completedEvent.complete(false)
             }
         }
-        if #available(iOS 17.0, *) {
-            ScrollView {
-                ForEach(eventLogs) { eventLog in
-                    Text(eventLog.log)
-                }
+        ScrollView {
+            ForEach(eventLogs) { eventLog in
+                Text(eventLog.log)
             }
-                .defaultScrollAnchor(.top)
         }
     }
 }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -64,78 +64,82 @@ struct ContentView: View {
     
     
     var body: some View {
-        Text("Scheduler")
-            .font(.headline)
-        Text("\(tasks) Tasks")
-        Text("\(events) Events")
-        Text("\(pastEvents) Past Events")
-        Text("Fulfilled \(fulfilledEvents) Events")
-        Button("Request Notification Permissions") {
-            _Concurrency.Task {
-                try await scheduler.requestLocalNotificationAuthorization()
-                notificationAuthorizationGranted = await scheduler.localNotificationAuthorization
-            }
+        Group {
+            Text("Scheduler")
+                .font(.headline)
+            Text("\(tasks) Tasks")
+            Text("\(events) Events")
+            Text("\(pastEvents) Past Events")
+            Text("Fulfilled \(fulfilledEvents) Events")
         }
+        Group { // swiftlint:disable:this closure_body_length
+            Button("Request Notification Permissions") {
+                _Concurrency.Task {
+                    try await scheduler.requestLocalNotificationAuthorization()
+                    notificationAuthorizationGranted = await scheduler.localNotificationAuthorization
+                }
+            }
             .disabled(notificationAuthorizationGranted)
-        Button("Add Task") {
-            _Concurrency.Task {
-                await scheduler.schedule(
-                    task: Task(
-                        title: "New Task",
-                        description: "New Task",
-                        schedule: Schedule(
-                            start: .now,
-                            repetition: .matching(.init(nanosecond: 0)), // Every full second
-                            end: .numberOfEvents(2)
-                        ),
-                        context: "New Task!"
+            Button("Add Task") {
+                _Concurrency.Task {
+                    await scheduler.schedule(
+                        task: Task(
+                            title: "New Task",
+                            description: "New Task",
+                            schedule: Schedule(
+                                start: .now,
+                                repetition: .matching(.init(nanosecond: 0)), // Every full second
+                                end: .numberOfEvents(2)
+                            ),
+                            context: "New Task!"
+                        )
                     )
-                )
+                }
             }
-        }
-        Button("Add Notification Task") {
-            _Concurrency.Task {
-                let currentDate = Date.now
-                let hour = Calendar.current.component(.hour, from: currentDate)
-                // We expect the UI test to take at least 20 seconds to mavigate out of the app and to the home screen.
-                // We then trigger the task in the minute after that, the UI test needs to wait at least one minute.
-                let minute = Calendar.current.component(.minute, from: currentDate.addingTimeInterval(20)) + 1
-                
-                // We schedule 128 notifications to test that the schedule limit to 64 notifications per device is enforced
-                // and notifications show on the device (iOS only limits up to 64 scheduled local notifications.
-                await scheduler.schedule(
-                    task: Task(
-                        title: "Notification Task",
-                        description: "Notification Task",
-                        schedule: Schedule(
-                            start: .now,
-                            repetition: .matching(.init(hour: hour, minute: minute)),
-                            end: .numberOfEvents(128)
-                        ),
-                        notifications: true,
-                        context: "Notification Task!"
+            Button("Add Notification Task") {
+                _Concurrency.Task {
+                    let currentDate = Date.now
+                    let hour = Calendar.current.component(.hour, from: currentDate)
+                    // We expect the UI test to take at least 20 seconds to mavigate out of the app and to the home screen.
+                    // We then trigger the task in the minute after that, the UI test needs to wait at least one minute.
+                    let minute = Calendar.current.component(.minute, from: currentDate.addingTimeInterval(20)) + 1
+                    
+                    // We schedule 128 notifications to test that the schedule limit to 64 notifications per device is enforced
+                    // and notifications show on the device (iOS only limits up to 64 scheduled local notifications.
+                    await scheduler.schedule(
+                        task: Task(
+                            title: "Notification Task",
+                            description: "Notification Task",
+                            schedule: Schedule(
+                                start: .now,
+                                repetition: .matching(.init(hour: hour, minute: minute)),
+                                end: .numberOfEvents(128)
+                            ),
+                            notifications: true,
+                            context: "Notification Task!"
+                        )
                     )
-                )
+                }
             }
-        }
-        Button("Fulfill Event") {
-            guard let uncompletedEvent = scheduler.tasks
-                .flatMap({ $0.events() })
-                .first(where: { !$0.complete }) else {
-                return
+            Button("Fulfill Event") {
+                guard let uncompletedEvent = scheduler.tasks
+                    .flatMap({ $0.events() })
+                    .first(where: { !$0.complete }) else {
+                    return
+                }
+                _Concurrency.Task {
+                    await uncompletedEvent.complete(true)
+                }
             }
-            _Concurrency.Task {
-                await uncompletedEvent.complete(true)
-            }
-        }
-        Button("Unfulfull Event") {
-            guard let completedEvent = scheduler.tasks
-                .flatMap({ $0.events() })
-                .first(where: { $0.complete }) else {
-                return
-            }
-            _Concurrency.Task {
-                await completedEvent.complete(false)
+            Button("Unfulfull Event") {
+                guard let completedEvent = scheduler.tasks
+                    .flatMap({ $0.events() })
+                    .first(where: { $0.complete }) else {
+                    return
+                }
+                _Concurrency.Task {
+                    await completedEvent.complete(false)
+                }
             }
         }
         ScrollView {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -479,115 +479,6 @@
 			};
 			name = Release;
 		};
-		2FB07587299DDB6000C0B37F /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Test;
-		};
-		2FB07588299DDB6000C0B37F /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 64FJ2MWNP4;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_TESTING_SEARCH_PATHS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Test;
-		};
-		2FB07589299DDB6000C0B37F /* Test */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 64FJ2MWNP4;
-				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testappuitests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = TestApp;
-			};
-			name = Test;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -595,7 +486,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B428F5F386007C25D6 /* Debug */,
-				2FB07587299DDB6000C0B37F /* Test */,
 				2F6D13B528F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -605,7 +495,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B728F5F386007C25D6 /* Debug */,
-				2FB07588299DDB6000C0B37F /* Test */,
 				2F6D13B828F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -615,7 +504,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13BD28F5F386007C25D6 /* Debug */,
-				2FB07589299DDB6000C0B37F /* Test */,
 				2F6D13BE28F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -37,7 +37,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Test"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"


### PR DESCRIPTION
# Improve Notification Handling & Storage of State Information

## :recycle: Current situation & Problem
- Scheduling local notifications sometimes does not work or results in double notifications as noted down in #25.


## :gear: Release Notes 
- Improves the mechanism to save local state to disk to ensure that it is available across application launches.
- Improve logging to us OSLog.


## :books: Documentation
- No changes to the public API/


## :white_check_mark: Testing
- Functionality is validated using existing UI and unit tests.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
