### PR TITLE
Improve Test Stability and Scheduling Limit

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -48,8 +48,10 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     /// Creates a new ``Scheduler`` module.
     /// - Parameter prescheduleLimit: The number of prescheduled notifications that should be registerd.
     ///                               Must be bigger than 1 and smaller than the limit of 64 local notifications at a time.
+    ///                               We recommend setting the limit to a value lower than 64, e.g., 56, to ensure room inaccuracies in the iOS scheduling APIs.
+    ///                               The default value is `56`.
     /// - Parameter tasks: The initial set of ``Task``s.
-    public init(prescheduleNotificationLimit: Int = 64, tasks initialTasks: [Task<Context>] = []) {
+    public init(prescheduleNotificationLimit: Int = 56, tasks initialTasks: [Task<Context>] = []) {
         assert(
             prescheduleNotificationLimit >= 1 && prescheduleNotificationLimit <= 64,
             "The prescheduleLimit must be bigger than 1 and smaller than the limit of 64 local notifications at a time"

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -90,7 +90,7 @@ final class SchedulerTests: XCTestCase {
                 repetition: .randomBetween( // Randomly scheduled in the first half of each second.
                     start: .init(nanosecond: 450_000_000),
                     end: .init(nanosecond: 550_000_000)
-                ),
+                                          ),
                 end: .numberOfEvents(numberOfEvents)
             ),
             context: "This is a test context"
@@ -145,6 +145,7 @@ final class SchedulerTests: XCTestCase {
         
         let calledObjectWillChange = XCTestExpectation(description: "Called object will change during registration.")
         calledObjectWillChange.assertForOverFulfill = true
+        
         var cancellable = scheduler.objectWillChange
             .subscribe(on: expectationQueue)
             .sink {
@@ -165,6 +166,9 @@ final class SchedulerTests: XCTestCase {
         
         await fulfillment(of: [calledObjectWillChange], timeout: 1)
         cancellable.cancel()
+        
+        try await _Concurrency.Task.sleep(for: .seconds(1))
+        
         
         let expectationCompleteEvents = XCTestExpectation(description: "Complete all events")
         expectationCompleteEvents.expectedFulfillmentCount = numberOfEvents * 2
@@ -194,7 +198,7 @@ final class SchedulerTests: XCTestCase {
                 expectationCompleteEvents.fulfill()
             }
         }
-    
+        
         await fulfillment(of: [expectationCompleteEvents, expectationObservedObject], timeout: (Double(numberOfEvents) * 2 * 0.5) + 3)
         cancellable.cancel()
         


### PR DESCRIPTION
# Improve Test Stability and Scheduling Limit

## :recycle: Current situation & Problem
- Scheduling sometimes fails due to some inaccuracies and saved notifications across application installations.


## :gear: Release Notes 
- Decreases the scheduling limit to to 56 notifications at the same time.
- Improves timeouts in tests.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
