### PR TITLE
Add a Constant Storage Key

### DIFF
--- a/Sources/SpeziScheduler/Constants.swift
+++ b/Sources/SpeziScheduler/Constants.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+enum Constants {
+    static let taskStorageKey: String = "spezi.scheduler.tasks"
+}

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -83,7 +83,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
         )
         
         _Concurrency.Task {
-            guard let storedTasks = try? localStorage.read([Task<Context>].self) else {
+            guard let storedTasks = try? localStorage.read([Task<Context>].self, storageKey: Constants.taskStorageKey) else {
                 await schedule(tasks: initialTasks)
                 return
             }
@@ -161,7 +161,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     
     func persistChanges() {
         do {
-            try self.localStorage.store(self.tasks)
+            try self.localStorage.store(self.tasks, storageKey: Constants.taskStorageKey)
         } catch {
             os_log(.error, "Spezi.Scheduler: Could not persist the tasks of the scheduler module: \(error)")
         }


### PR DESCRIPTION
# Add a Constant Storage Key

## :recycle: Current situation & Problem
- Any changes to the name of the generic context results in the generation of a new local storage while which might hinder backwards compatibility of the Scheduler module in case the name or type changes in a backward compatible manner.
- We encounter a crash on iOS 16.6.1 that seems to relate to thin metadata not being available to the runtime to infer the type name in storing information in the local storage module:
![Screenshot 2023-09-12 at 6 49 24 PM (1)](https://github.com/StanfordSpezi/SpeziScheduler/assets/28656495/4b9204aa-acb1-46d8-a2d0-42fc3205da26)



## :gear: Release Notes 
- Fixes the issues by adding a constant storage key for elements stored by the Scheduler module.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
