### PR TITLE
Improve Concurrent Access to the Local Storage

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -163,18 +163,8 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     @MainActor
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) async {
-        await sendObjectWillChange()
-    }
-    
-    @_documentation(visibility: internal)
-    @MainActor
-    public func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        await sendObjectWillChange()
         return [.badge, .banner, .sound, .list]
     }
     

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -132,7 +132,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     }
     
     // Unfortunately, the async overload of the `UNUserNotificationCenterDelegate` results in a runtime crash.
-    // Reverify this in iOS versions after iOS 17.0
+    // Crashes on iOS 16.6.1. Reverify this in iOS versions after pushing the deployment target to iOS 17.0
     @_documentation(visibility: internal)
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
@@ -146,7 +146,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     }
     
     // Unfortunately, the async overload of the `UNUserNotificationCenterDelegate` results in a runtime crash.
-    // Reverify this in iOS versions after iOS 17.0
+    // Crashes on iOS 16.6.1. Reverify this in iOS versions after pushing the deployment target to iOS 17.0
     @_documentation(visibility: internal)
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -165,7 +165,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        return [.badge, .banner, .sound, .list]
+        [.badge, .banner, .sound, .list]
     }
     
     


### PR DESCRIPTION
# Improve Concurrent Access to the Local Storage

## :recycle: Current situation & Problem
- We are currently getting crash reports on iOS 16.6.1 about crashes when using the local storage module for storing information in the scheduler.


## :gear: Release Notes 
- Adds additional locking mechanisms for the local storage access to reduce possible errors due to race conditions.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
