### PR TITLE
Improve Scheduler Initializer and Fix Issue Where Tasks That Are Overdue at Creation Are Not Updated

### DIFF
--- a/Sources/SpeziScheduler/Model/Event.swift
+++ b/Sources/SpeziScheduler/Model/Event.swift
@@ -71,7 +71,14 @@ public final class Event: Identifiable, @unchecked Sendable {
     }
 
     convenience init(taskId: UUID, scheduledAt: Date) {
-        self.init(state: .scheduled(at: scheduledAt), taskId: taskId)
+        let state: EventState
+        if scheduledAt < .now {
+            state = .overdue(since: scheduledAt)
+        } else {
+            state = .scheduled(at: scheduledAt)
+        }
+        
+        self.init(state: state, taskId: taskId)
     }
 
 

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -19,7 +19,8 @@ import UserNotifications
 /// Use the ``Scheduler/init(prescheduleNotificationLimit:tasks:)`` initializer or the ``Scheduler/schedule(task:)`` function
 /// to schedule tasks that you can obtain using the ``Scheduler/tasks`` property.
 /// You can use the ``Scheduler`` as an `ObservableObject` to automatically update your SwiftUI views when new events are emitted or events change.
-public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDelegate, Module, LifecycleHandler, EnvironmentAccessible {
+public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDelegate,
+                                          Module, LifecycleHandler, EnvironmentAccessible, DefaultInitializable {
     private let logger = Logger(subsystem: "edu.stanford.spezi.scheduler", category: "Scheduler")
 
     @Dependency private var storage: SchedulerStorage<Context>
@@ -28,7 +29,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     private let initialTasks: [Task<Context>]
     private let prescheduleNotificationLimit: Int
 
-    private let taskList: TaskList<Context>
+    private var taskList: TaskList<Context> = TaskList<Context>()
 
     public var tasks: [Task<Context>] {
         taskList.tasks
@@ -54,15 +55,11 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
             prescheduleNotificationLimit >= 1 && prescheduleNotificationLimit <= 64,
             "The prescheduleLimit must be bigger than 1 and smaller than the limit of 64 local notifications at a time"
         )
-
-        let list = TaskList<Context>()
-
+        
         self.prescheduleNotificationLimit = prescheduleNotificationLimit
         self.initialTasks = initialTasks
-        self.taskList = list
-
-        self._storage = Dependency(wrappedValue: SchedulerStorage(taskList: list))
-
+        self._storage = Dependency(wrappedValue: SchedulerStorage(taskList: self.taskList))
+        
         super.init()
         
         // Only run the notification setup when not running unit tests:
@@ -74,6 +71,10 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
                 firstLaunch = false
             }
         }
+    }
+    
+    override public required convenience init() {
+        self.init(tasks: [])
     }
     
     

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -29,7 +29,7 @@ public class Scheduler<Context: Codable>: NSObject, UNUserNotificationCenterDele
     private let initialTasks: [Task<Context>]
     private let prescheduleNotificationLimit: Int
 
-    private var taskList: TaskList<Context> = TaskList<Context>()
+    private let taskList: TaskList<Context> = TaskList<Context>()
 
     public var tasks: [Task<Context>] {
         taskList.tasks


### PR DESCRIPTION
# Improve Scheduler Initializer and Fix Issue Where Tasks That Are Overdue at Creation Are Not Updated


## :gear: Release Notes 
- `Scheduler` conforms to `DefaultInitializable`
-  Fix issue where tasks that are overdue at creation are not updated

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
