### PR TITLE
Bug Fix: SpeziScheduler multiple task app crash

### DIFF
--- a/Sources/SpeziScheduler/Model/Event.swift
+++ b/Sources/SpeziScheduler/Model/Event.swift
@@ -230,6 +230,6 @@ extension Event: Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(state)
+        hasher.combine(scheduledAt)
     }
 }

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -281,23 +281,23 @@ final class SchedulerTests: XCTestCase {
         let task = try JSONDecoder().decode(Task<String>.self, from: Data(json.utf8))
         XCTAssertEqual(task.schedule.calendar, .current)
     }
-    @MainActor 
+    @MainActor
     func testEventHashEqualityForScheduledVsCompleted() throws {
         let taskId = UUID()
         let scheduledDate = Date()
         let scheduledEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
-
+        
         let completedEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
         completedEvent.complete(true)
-
+        
         var scheduledEventHasher = Hasher()
         scheduledEvent.hash(into: &scheduledEventHasher)
         let scheduledEventHash = scheduledEventHasher.finalize()
-
+        
         var completedEventHasher = Hasher()
         completedEvent.hash(into: &completedEventHasher)
         let completedEventHash = completedEventHasher.finalize()
-
+        
         XCTAssertEqual(scheduledEventHash, completedEventHash)
     }
 }

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -282,16 +282,13 @@ final class SchedulerTests: XCTestCase {
         XCTAssertEqual(task.schedule.calendar, .current)
     }
     @MainActor func testEventHashEqualityForScheduledVsCompleted() throws {
-        // Creates a scheduled event
         let taskId = UUID()
         let scheduledDate = Date()
         let scheduledEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
 
-        // Creating a completed event identical to the scheduled one but marked as complete
         let completedEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
         completedEvent.complete(true)
 
-        // Verifying that both events produce the same hash
         var scheduledEventHasher = Hasher()
         scheduledEvent.hash(into: &scheduledEventHasher)
         let scheduledEventHash = scheduledEventHasher.finalize()
@@ -300,7 +297,6 @@ final class SchedulerTests: XCTestCase {
         completedEvent.hash(into: &completedEventHasher)
         let completedEventHash = completedEventHasher.finalize()
 
-        // Checking if the two instances of Event produce the same hash
         XCTAssertEqual(scheduledEventHash, completedEventHash)
     }
 }

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -281,13 +281,21 @@ final class SchedulerTests: XCTestCase {
         let task = try JSONDecoder().decode(Task<String>.self, from: Data(json.utf8))
         XCTAssertEqual(task.schedule.calendar, .current)
     }
-    @MainActor func testEventHashEqualityForScheduledVsCompleted() throws {
+    func testEventHashScheduledVsCompleted() throws {
         let taskId = UUID()
         let scheduledDate = Date()
         let scheduledEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
 
         let completedEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
-        completedEvent.complete(true)
+
+        let expectation = XCTestExpectation(description: "Complete event on main actor")
+
+        DispatchQueue.main.async {
+            completedEvent.complete(true)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
 
         var scheduledEventHasher = Hasher()
         scheduledEvent.hash(into: &scheduledEventHasher)

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -281,21 +281,14 @@ final class SchedulerTests: XCTestCase {
         let task = try JSONDecoder().decode(Task<String>.self, from: Data(json.utf8))
         XCTAssertEqual(task.schedule.calendar, .current)
     }
-    func testEventHashScheduledVsCompleted() throws {
+    @MainActor 
+    func testEventHashEqualityForScheduledVsCompleted() throws {
         let taskId = UUID()
         let scheduledDate = Date()
         let scheduledEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
 
         let completedEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
-
-        let expectation = XCTestExpectation(description: "Complete event on main actor")
-
-        DispatchQueue.main.async {
-            completedEvent.complete(true)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 1.0)
+        completedEvent.complete(true)
 
         var scheduledEventHasher = Hasher()
         scheduledEvent.hash(into: &scheduledEventHasher)

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -281,4 +281,26 @@ final class SchedulerTests: XCTestCase {
         let task = try JSONDecoder().decode(Task<String>.self, from: Data(json.utf8))
         XCTAssertEqual(task.schedule.calendar, .current)
     }
+    @MainActor func testEventHashEqualityForScheduledVsCompleted() throws {
+        // Creates a scheduled event
+        let taskId = UUID()
+        let scheduledDate = Date()
+        let scheduledEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
+
+        // Creating a completed event identical to the scheduled one but marked as complete
+        let completedEvent = Event(taskId: taskId, scheduledAt: scheduledDate)
+        completedEvent.complete(true)
+
+        // Verifying that both events produce the same hash
+        var scheduledEventHasher = Hasher()
+        scheduledEvent.hash(into: &scheduledEventHasher)
+        let scheduledEventHash = scheduledEventHasher.finalize()
+
+        var completedEventHasher = Hasher()
+        completedEvent.hash(into: &completedEventHasher)
+        let completedEventHash = completedEventHasher.finalize()
+
+        // Checking if the two instances of Event produce the same hash
+        XCTAssertEqual(scheduledEventHash, completedEventHash)
+    }
 }


### PR DESCRIPTION
# Bug Fix: SpeziScheduler multiple task app crash

## :recycle: Current situation & Problem
Fixing the following issue: https://github.com/StanfordSpezi/SpeziScheduler/issues/36


## :gear: Release Notes 
 - New bug fix allows you to add multiple tasks without crashing
 - Each of the tasks can now be completed without errors, with each task's updated completion text and icon showing up.


## :books: Documentation
https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md
DETAILS:
When I try to add multiple tasks in a single day in the schedule that uses SpeziScheduler, running the app causes it to crash, with the error message "Fatal error: Duplicate keys of type 'Event' were found in a Dictionary.
This usually means either that the type violates Hashable's requirements, or
that members of such a dictionary were mutated after insertion. The template app's PICSScheduler file (our project's version of it) initially has only the single task with static var SocialSupportTask: SpeziScheduler.Task, but I modified that to include 3 tasks instead of just 1, so it now includes:
static var PHQ4Task: SpeziScheduler.Task, static var EQ5D5LTask: SpeziScheduler.Task, and static var MiniNutritionalTask: SpeziScheduler.Task

And, the final convenience init is to incorporate:
convenience init() {
self.init(tasks: [Self.PHQ4Task, Self.EQ5D5LTask, Self.MiniNutritionalTask])}

These changes seem to have been enough to cause the error.
Full details about reasoning here: https://github.com/StanfordSpezi/SpeziScheduler/issues/36


## :white_check_mark: Testing
Added a new Unit Test to SpeziScheduler to check whether the two instances of Event (once when completed, and once when not completed) produce the same hash


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
