### PR TITLE
Disable persistent storage of Tasks in simulator

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,22 +16,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build Swift Package on Xcode 14
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziScheduler
-      test: false
-  buildandtest:
+  buildandtest_ios:
     name: Build and Test Swift Package
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      xcodeversion: latest
-      artifactname: SpeziScheduler.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziScheduler
-  buildandtestuitests:
+      resultBundle: SpeziScheduler-iOS.xcresult
+      artifactname: SpeziScheduler-iOS.xcresult
+  buildandtest_watchos:
+    name: Build and Test Swift Package watchOS
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      scheme: SpeziScheduler
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'
+      resultBundle: SpeziScheduler-watchOS.xcresult
+      artifactname: SpeziScheduler-watchOS.xcresult
+  buildandtest_visionos:
+    name: Build and Test Swift Package visionOS
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      scheme: SpeziScheduler
+      destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
+      resultBundle: SpeziScheduler-visionOS.xcresult
+      artifactname: SpeziScheduler-visionOS.xcresult
+  buildandtest_macos:
+    name: Build and Test Swift Package macOS
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macOS", "self-hosted"]'
+      scheme: SpeziScheduler
+      destination: 'platform=macOS,arch=arm64'
+      resultBundle: SpeziScheduler-macOS.xcresult
+      artifactname: SpeziScheduler-macOS.xcresult
+  buildandtestuitests_ios:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
@@ -42,7 +62,7 @@ jobs:
       scheme: TestApp
   uploadcoveragereport:
     name: Upload Coverage Report
-    needs: [buildandtest, buildandtestuitests]
+    needs: [buildandtest_ios, buildandtest_watchos, buildandtest_visionos, buildandtest_macos, buildandtestuitests_ios]
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: SpeziScheduler.xcresult TestApp.xcresult
+      coveragereports: SpeziScheduler-iOS.xcresult SpeziScheduler-watchOS.xcresult SpeziScheduler-visionOS.xcresult SpeziScheduler-macOS.xcresult TestApp.xcresult

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -367,9 +367,6 @@ only_rules:
   # The variable should be placed on the left, the constant on the right of a comparison operator.
   - yoda_condition
 
-attributes:
-  attributes_with_arguments_always_on_line_above: false
-
 deployment_target: # Availability checks or attributes shouldn’t be using older versions that are satisfied by the deployment target.
   iOSApplicationExtension_deployment_target: 16.0
   iOS_deployment_target: 16.0

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "SpeziScheduler", targets: ["SpeziScheduler"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.0"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.3"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,17 @@ import PackageDescription
 let package = Package(
     name: "SpeziScheduler",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17),
+        .macOS(.v14),
+        .visionOS(.v1),
+        .watchOS(.v10)
     ],
     products: [
         .library(name: "SpeziScheduler", targets: ["SpeziScheduler"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.0")
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.2")
     ],
     targets: [
         .target(

--- a/Sources/SpeziScheduler/Model/TaskList.swift
+++ b/Sources/SpeziScheduler/Model/TaskList.swift
@@ -24,6 +24,17 @@ final class TaskList<Context: Codable> {
 }
 
 
+extension TaskList: Hashable {
+    static func == (lhs: TaskList<Context>, rhs: TaskList<Context>) -> Bool {
+        lhs.tasks == rhs.tasks
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(tasks)
+    }
+}
+
+
 extension TaskList: MutableCollection {
     public var startIndex: Int {
         tasks.startIndex

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -26,11 +26,14 @@ public class Scheduler<Context: Codable>: Module, EnvironmentAccessible, Default
     @Dependency private var storage: SchedulerStorage<Context>
     @Modifier private var modifier = SchedulerLifecycle<Context>()
 
-    @AppStorage("Spezi.Scheduler.firstlaunch") private var firstLaunch = true
+    @AppStorage("Spezi.Scheduler.firstlaunch")
+    private var firstLaunch = true
     private let initialTasks: [Task<Context>]
     private let prescheduleNotificationLimit: Int
 
-    private let taskList: TaskList<Context> = TaskList<Context>()
+    private var taskList: TaskList<Context> {
+        storage.taskList
+    }
 
     public var tasks: [Task<Context>] {
         taskList.tasks
@@ -59,7 +62,6 @@ public class Scheduler<Context: Codable>: Module, EnvironmentAccessible, Default
         
         self.prescheduleNotificationLimit = prescheduleNotificationLimit
         self.initialTasks = initialTasks
-        self._storage = Dependency(wrappedValue: SchedulerStorage(taskList: self.taskList))
         
         // Only run the notification setup when not running unit tests:
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
@@ -147,17 +149,6 @@ public class Scheduler<Context: Codable>: Module, EnvironmentAccessible, Default
 
         return [.badge, .banner, .sound, .list]
     }
-
-    public func handleNotificationAction(_ response: UNNotificationResponse) async {} // TODO: removew
-    #if !os(macOS)
-    public func receiveRemoteNotification(_ remoteNotification: [AnyHashable : Any]) async -> BackgroundFetchResult { // TODO: remove
-        .noData
-    }
-    #else
-    public func receiveRemoteNotification(_ remoteNotification: [AnyHashable : Any]) { // TODO: remove
-
-    }
-    #endif
 
     
     // MARK: - Helper Methods

--- a/Sources/SpeziScheduler/SchedulerLifecycle.swift
+++ b/Sources/SpeziScheduler/SchedulerLifecycle.swift
@@ -1,0 +1,35 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SwiftUI
+
+
+struct SchedulerLifecycle<Context: Codable>: ViewModifier {
+    @Environment(Scheduler<Context>.self)
+    private var scheduler
+
+    @Environment(\.scenePhase)
+    private var scenePhase
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: scenePhase) {
+                guard scenePhase == .active else {
+                    return
+                }
+
+                scheduler.handleActiveScenePhase()
+            }
+        #if !os(watchOS)
+            .onReceive(NotificationCenter.default.publisher(for: _Application.willTerminateNotification)) { _ in
+                scheduler.handleApplicationWillTerminate()
+            }
+        #endif
+    }
+}

--- a/Sources/SpeziScheduler/SchedulerStorage.swift
+++ b/Sources/SpeziScheduler/SchedulerStorage.swift
@@ -52,7 +52,12 @@ public actor SchedulerStorage<Context: Codable>: Module, DefaultInitializable, A
     func loadTasks() -> [Task<Context>]? {
         // swiftlint:disable:previous discouraged_optional_collection
         if storageIsMocked {
-            logger.info("Storage is disabled as we are running int the simulator. No tasks were loaded.")
+            logger.debug("""
+                         Storage is disabled as we are running int the simulator. No tasks were loaded.
+
+                         To enable storage even if running within the simulator you can add the following module to your Spezi configuration:
+                         SchedulerStorage(for: Scheduler<\(Context.self)>.self, mockedStorage=false)
+                         """)
             return nil
         }
 
@@ -66,7 +71,12 @@ public actor SchedulerStorage<Context: Codable>: Module, DefaultInitializable, A
 
     func storeTasks() {
         if storageIsMocked {
-            logger.info("Storage is disabled as we are running int the simulator. No tasks were saved.")
+            logger.debug("""
+                         Storage is disabled as we are running int the simulator. No tasks were saved.
+
+                         To enable storage even if running within the simulator you can add the following module to your Spezi configuration:
+                         SchedulerStorage(for: Scheduler<\(Context.self)>.self, mockedStorage=false)
+                         """)
             return
         }
 

--- a/Sources/SpeziScheduler/SchedulerStorage.swift
+++ b/Sources/SpeziScheduler/SchedulerStorage.swift
@@ -43,20 +43,24 @@ actor SchedulerStorage<Context: Codable>: Module, DefaultInitializable, AnyStora
 
     func loadTasks() -> [Task<Context>]? {
         // swiftlint:disable:previous discouraged_optional_collection
+        #if !targetEnvironment(simulator)
         do {
             return try localStorage.read([Task<Context>].self, storageKey: Constants.taskStorageKey)
         } catch {
             logger.error("Could not retrieve tasks from storage for the scheduler module: \(error)")
         }
+        #endif
         return nil
     }
 
     func storeTasks() {
+        #if !targetEnvironment(simulator)
         do {
             try localStorage.store(taskList.tasks, storageKey: Constants.taskStorageKey)
         } catch {
             logger.error("Could not persist the tasks of the scheduler module: \(error)")
         }
+        #endif
     }
 
     nonisolated func signalChange() {

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -14,16 +14,6 @@ import XCTest
 import XCTSpezi
 
 
-struct ExampleView: View {
-    @State private var viewModel: FoodEntryViewModel
-
-
-    init(foodEntry: FoodEntry, day: String, meal: String) {
-        viewModel = FoodEntryViewModel(foodEntry: foodEntry, day: day, meal: meal)
-    }
-}
-
-
 final class SchedulerTests: XCTestCase {
     private func createScheduler(withInitialTasks initialTasks: Task<String>) async throws -> Scheduler<String> {
         let scheduler = Scheduler<String>(tasks: [initialTasks])

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -14,6 +14,16 @@ import XCTest
 import XCTSpezi
 
 
+struct ExampleView: View {
+    @State private var viewModel: FoodEntryViewModel
+
+
+    init(foodEntry: FoodEntry, day: String, meal: String) {
+        viewModel = FoodEntryViewModel(foodEntry: foodEntry, day: day, meal: meal)
+    }
+}
+
+
 final class SchedulerTests: XCTestCase {
     private func createScheduler(withInitialTasks initialTasks: Task<String>) async throws -> Scheduler<String> {
         let scheduler = Scheduler<String>(tasks: [initialTasks])

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -22,7 +22,8 @@ struct ContentView: View {
     }
     
     
-    @Environment(TestAppScheduler.self) private var scheduler
+    @Environment(TestAppScheduler.self)
+    private var scheduler
     @State private var notificationAuthorizationGranted = false
     
     

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -12,7 +12,8 @@ import SwiftUI
 
 @main
 struct UITestsApp: App {
-    @UIApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate
+    @UIApplicationDelegateAdaptor(TestAppDelegate.self)
+    var appDelegate
     
     
     var body: some Scene {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 import Spezi
-import SpeziScheduler
+@_spi(Spezi) import SpeziScheduler // swiftlint:disable:this attributes
 
 
 typealias TestAppScheduler = Scheduler<String>
@@ -16,6 +16,8 @@ typealias TestAppScheduler = Scheduler<String>
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration {
+            // ensure storage is not mocked even though we are running within the simulator
+            SchedulerStorage(for: TestAppScheduler.self, mockedStorage: false)
             TestAppScheduler(
                 tasks: [
                     Task(

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1530;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -314,12 +314,14 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -368,12 +370,14 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
@@ -400,10 +404,14 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -430,10 +438,14 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.scheduler.testapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};
@@ -449,9 +461,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.Spezi.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_TARGET_NAME = TestApp;
 			};
 			name = Debug;
@@ -468,9 +484,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.Spezi.testappuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_TARGET_NAME = TestApp;
 			};
 			name = Release;
@@ -513,7 +533,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.7;
+				minimumVersion = 0.4.10;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1530"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# Disable persistent storage of Tasks in simulator

## :recycle: Current situation & Problem
We found it overly complicated to deal with SpeziScheduler in the development process (e.g., testing changes within the simulator or running unit tests against a scheduler implementation).
This PR changes the SchedulerStorage component to not interact with the local storage if running within a simulator environment. This should allow for more rapid development (e.g., no requirement to delete the app in between startups) and help in unit testing scenarios.

Additionally, this PR fixes the Equatable implementation of the `Scheduler` module.

Lastly, we update to the latest Spezi release and remove usage of the `LifecycleHandler` and avoid directly interfacing with the NotificationDelegate. This ensure that we don't override the Notification Center delegate from someone else and, most importantly, only respond to notifications the scheduler sent.

## :gear: Release Notes 
* Disable persistent storage of Tasks and Events in simulator environments for easier development.
* Fix Equatable implementation of the `Scheduler`.
* Update to new Spezi release, replacing `LifecycleHandler` implementation with SwiftUI native mechanisms.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
