### PR TITLE
Let Scheduler Conform to DefaultInitializable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziScheduler-Package
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (45mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
       resultBundle: SpeziScheduler-watchOS.xcresult
       artifactname: SpeziScheduler-watchOS.xcresult
   buildandtest_visionos:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziScheduler-Package
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (45mm)'
       resultBundle: SpeziScheduler-watchOS.xcresult
       artifactname: SpeziScheduler-watchOS.xcresult
   buildandtest_visionos:

--- a/Sources/SpeziScheduler/Notifications/Schedule+Notifications.swift
+++ b/Sources/SpeziScheduler/Notifications/Schedule+Notifications.swift
@@ -38,13 +38,13 @@ extension Schedule {
         }
     }
 
-    static func notificationMatchingHint( // swiftlint:disable:this function_parameter_count function_default_parameter_at_end
+    static func notificationMatchingHint( // swiftlint:disable:this function_parameter_count
         forMatchingInterval interval: Int,
         calendar: Calendar,
         hour: Int,
         minute: Int,
         second: Int,
-        weekday: Int? = nil,
+        weekday: Int? = nil, // swiftlint:disable:this function_default_parameter_at_end
         consider duration: Duration
     ) -> NotificationMatchingHint? {
         guard interval == 1 else {

--- a/Sources/SpeziScheduler/Schedule/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule/Schedule.swift
@@ -259,12 +259,12 @@ extension Schedule {
     ///   - end: Optional end date of the schedule. Otherwise, it repeats indefinitely.
     ///   - duration: The duration of a single occurrence. By default one hour.
     /// - Returns: Returns the schedule that repeats daily.
-    public static func daily( // swiftlint:disable:this function_default_parameter_at_end
-        calendar: Calendar = .current,
-        interval: Int = 1,
+    public static func daily(
+        calendar: Calendar = .current, // swiftlint:disable:this function_default_parameter_at_end
+        interval: Int = 1, // swiftlint:disable:this function_default_parameter_at_end
         hour: Int,
         minute: Int,
-        second: Int = 0,
+        second: Int = 0, // swiftlint:disable:this function_default_parameter_at_end
         startingAt start: Date,
         end: Calendar.RecurrenceRule.End = .never,
         duration: Duration = .tillEndOfDay
@@ -308,13 +308,13 @@ extension Schedule {
     ///   - end: Optional end date of the schedule. Otherwise, it repeats indefinitely.
     ///   - duration: The duration of a single occurrence. By default one hour.
     /// - Returns: Returns the schedule that repeats weekly.
-    public static func weekly( // swiftlint:disable:this function_default_parameter_at_end
+    public static func weekly(
         calendar: Calendar = .current,
         interval: Int = 1,
-        weekday: Locale.Weekday? = nil,
+        weekday: Locale.Weekday? = nil, // swiftlint:disable:this function_default_parameter_at_end
         hour: Int,
         minute: Int,
-        second: Int = 0,
+        second: Int = 0, // swiftlint:disable:this function_default_parameter_at_end
         startingAt start: Date,
         end: Calendar.RecurrenceRule.End = .never,
         duration: Duration = .tillEndOfDay

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -481,7 +481,7 @@ public final class Scheduler {
 }
 
 
-extension Scheduler: Module, EnvironmentAccessible, Sendable {}
+extension Scheduler: Module, EnvironmentAccessible, DefaultInitializable, Sendable {}
 
 
 extension Scheduler {

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -219,11 +219,11 @@ public final class Scheduler {
     ///   - contextClosure: The closure that allows to customize the ``Task/Context`` that is stored with the task.
     /// - Returns: Returns the latest version of the `task` and if the task was updated or created indicated by `didChange`.
     @discardableResult
-    public func createOrUpdateTask( // swiftlint:disable:this function_default_parameter_at_end function_body_length
+    public func createOrUpdateTask( // swiftlint:disable:this function_body_length
         id: String,
         title: String.LocalizationValue,
         instructions: String.LocalizationValue,
-        category: Task.Category? = nil,
+        category: Task.Category? = nil, // swiftlint:disable:this function_default_parameter_at_end
         schedule: Schedule,
         completionPolicy: AllowedCompletionPolicy = .sameDay,
         scheduleNotifications: Bool = false,
@@ -593,11 +593,11 @@ extension Scheduler {
         return try context.fetchCount(descriptor) > 0
     }
 
-    private func queryTasks( // swiftlint:disable:this function_default_parameter_at_end
+    private func queryTasks(
         with basePredicate: Predicate<Task>,
         combineWith userPredicate: Predicate<Task>,
         sortBy sortDescriptors: [SortDescriptor<Task>],
-        fetchLimit: Int? = nil,
+        fetchLimit: Int? = nil, // swiftlint:disable:this function_default_parameter_at_end
         prefetchOutcomes: Bool
     ) throws -> [Task] {
         var descriptor = FetchDescriptor<Task>(

--- a/Sources/SpeziSchedulerMacros/SpeziSchedulerDiagnostic.swift
+++ b/Sources/SpeziSchedulerMacros/SpeziSchedulerDiagnostic.swift
@@ -35,10 +35,10 @@ struct SpeziSchedulerDiagnostic: DiagnosticMessage {
 
 
 extension Diagnostic {
-    init<S: SyntaxProtocol>( // swiftlint:disable:this function_default_parameter_at_end
+    init<S: SyntaxProtocol>(
         syntax: S,
         message: String,
-        domain: String = "SpeziScheduler",
+        domain: String = "SpeziScheduler", // swiftlint:disable:this function_default_parameter_at_end
         id: SpeziSchedulerDiagnostic.ID,
         severity: SwiftDiagnostics.DiagnosticSeverity = .error
     ) {
@@ -48,10 +48,10 @@ extension Diagnostic {
 
 
 extension DiagnosticsError {
-    init<S: SyntaxProtocol>(  // swiftlint:disable:this function_default_parameter_at_end
+    init<S: SyntaxProtocol>(
         syntax: S,
         message: String,
-        domain: String = "SpeziScheduler",
+        domain: String = "SpeziScheduler", // swiftlint:disable:this function_default_parameter_at_end
         id: SpeziSchedulerDiagnostic.ID,
         severity: SwiftDiagnostics.DiagnosticSeverity = .error
     ) {


### PR DESCRIPTION
# Let Scheduler Conform to DefaultInitializable

## :recycle: Current situation & Problem
- As noted in https://github.com/StanfordSpezi/SpeziTemplateApplication/pull/98, `Scheduler` lost its conformance to `DefaultInitializable`, causing some previews to break in Spezi applications. It is reasonable to assume that `Scheduler` should conform to `DefaultInitializable` (https://github.com/StanfordSpezi/SpeziTemplateApplication/pull/98#issuecomment-2618173033)
 

## :gear: Release Notes 
- Let Scheduler Conform to `DefaultInitializable`


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
