### PR TITLE
fix `queryOutcomes` returning no results; make `Schedule` conform to `Hashable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
                 .product(name: "SwiftDiagnostics", package: "swift-syntax")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -57,6 +58,7 @@ let package = Package(
                 .product(name: "SpeziLocalStorage", package: "SpeziStorage"),
                 .product(name: "Algorithms", package: "swift-algorithms")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -68,6 +70,7 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -77,6 +80,7 @@ let package = Package(
                 .product(name: "XCTSpezi", package: "Spezi"),
                 .product(name: "SpeziLocalStorage", package: "SpeziStorage")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -87,6 +91,7 @@ let package = Package(
                 .product(name: "XCTSpezi", package: "Spezi"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -96,6 +101,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
             ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.7.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.1.2"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.1.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNotifications.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0-prerelease-2024-08-14"),

--- a/Sources/SpeziScheduler/Notifications/LegacyTaskModel.swift
+++ b/Sources/SpeziScheduler/Notifications/LegacyTaskModel.swift
@@ -11,33 +11,23 @@ import UserNotifications
 
 
 /// Minimal model of the legacy event model to retrieve data to provide some interoperability with the legacy version.
-struct LegacyEventModel {
+struct LegacyEventModel: Codable, Hashable, Sendable {
     let notification: UUID?
-}
-
-
-/// Minimal model of the legacy task model to retrieve data to provide some interoperability with the legacy version.
-struct LegacyTaskModel {
-    let id: UUID
-    let notifications: Bool
-    let events: [LegacyEventModel]
-}
-
-
-extension LegacyEventModel: Decodable, Hashable, Sendable {}
-
-
-extension LegacyTaskModel: Decodable, Hashable, Sendable {}
-
-
-extension LegacyEventModel {
+    
     func cancelNotification() {
         guard let notification else {
             return
         }
-
         let center = UNUserNotificationCenter.current()
         center.removeDeliveredNotifications(withIdentifiers: [notification.uuidString])
         center.removePendingNotificationRequests(withIdentifiers: [notification.uuidString])
     }
+}
+
+
+/// Minimal model of the legacy task model to retrieve data to provide some interoperability with the legacy version.
+struct LegacyTaskModel: Codable, Hashable, Sendable {
+    let id: UUID
+    let notifications: Bool
+    let events: [LegacyEventModel]
 }

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -552,7 +552,7 @@ extension SchedulerNotifications {
 
             lazy var content = {
                 let content = task.notificationContent()
-                if let standard = standard as? SchedulerNotificationsConstraint {
+                if let standard = standard as? any SchedulerNotificationsConstraint {
                     standard.notificationContent(for: task, content: content)
                 }
                 return content
@@ -592,7 +592,7 @@ extension SchedulerNotifications {
 
             lazy var content = {
                 let content = event.task.notificationContent()
-                if let standard = standard as? SchedulerNotificationsConstraint {
+                if let standard = standard as? any SchedulerNotificationsConstraint {
                     standard.notificationContent(for: event.task, content: content)
                 }
                 return content

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -737,14 +737,21 @@ extension SchedulerNotifications {
 
 // MARK: - Legacy Notifications
 
+extension LocalStorageKeys {
+    fileprivate static let legacyTasks = LocalStorageKey<[LegacyTaskModel]>(
+        "spezi.scheduler.tasks", // the legacy scheduler 1.0 used to store tasks at this location.
+        setting: .encryptedUsingKeychain(),
+        encoder: JSONEncoder(),
+        decoder: JSONDecoder()
+    )
+}
+
 extension SchedulerNotifications {
     /// Cancel scheduled and delivered notifications of the legacy SpeziScheduler 1.0
     fileprivate func purgeLegacyEventNotifications() {
-        let legacyStorageKey = "spezi.scheduler.tasks" // the legacy scheduler 1.0 used to store tasks at this location.
-
         let legacyTasks: [LegacyTaskModel]
         do {
-            legacyTasks = try localStorage.read(storageKey: legacyStorageKey)
+            legacyTasks = try localStorage.load(.legacyTasks) ?? []
         } catch {
             let nsError = error as NSError
             if nsError.domain == CocoaError.errorDomain
@@ -763,7 +770,7 @@ extension SchedulerNotifications {
 
         // We don't support migration, so just remove it.
         do {
-            try localStorage.delete(storageKey: legacyStorageKey)
+            try localStorage.delete(.legacyTasks)
         } catch {
             logger.warning("Failed to remove legacy scheduler task storage: \(error)")
         }

--- a/Sources/SpeziScheduler/Schedule/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule/Schedule.swift
@@ -196,7 +196,7 @@ public struct Schedule {
 }
 
 
-extension Schedule: Equatable, Sendable, Codable {/*
+extension Schedule: Hashable, Sendable, Codable {/*
     private enum CodingKeys: String, CodingKey {
         case startDate
         case scheduleDuration

--- a/Sources/SpeziScheduler/Schedule/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule/Schedule.swift
@@ -490,5 +490,3 @@ extension Data {
         }
     }
 }
-
-// swiftlint:disable:this file_length

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -653,6 +653,10 @@ extension Scheduler {
     private func queryOutcomes(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> [Outcome] {
         var descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
+                // Since, for some reason, `range.contains(outcome.occurrenceStartDate)` doesn't work in a #Predicate
+                // (it just filters out everything, even if the start date does in fact fall into the range),
+                // we instead need to rewrite what could otherwise be a `contains` call into explicit checks against the range's lower and upper bound.
+                // See also: https://github.com/StanfordSpezi/SpeziScheduler/pull/55#issuecomment-2667153659
                 // swiftlint:disable:next line_length
                 range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
             }
@@ -677,6 +681,10 @@ extension Scheduler {
     private func queryOutcomeIdentifiers(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> Set<PersistentIdentifier> {
         let descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
+                // Since, for some reason, `range.contains(outcome.occurrenceStartDate)` doesn't work in a #Predicate
+                // (it just filters out everything, even if the start date does in fact fall into the range),
+                // we instead need to rewrite what could otherwise be a `contains` call into explicit checks against the range's lower and upper bound.
+                // See also: https://github.com/StanfordSpezi/SpeziScheduler/pull/55#issuecomment-2667153659
                 // swiftlint:disable:next line_length
                 range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
             }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -475,7 +475,6 @@ public final class Scheduler {
     ) throws -> [Event] {
         let tasks = try queryTasks(for: range, predicate: taskPredicate)
         let outcomes = try queryOutcomes(for: range, predicate: taskPredicate)
-
         return assembleEvents(for: range, tasks: tasks, outcomes: outcomes)
     }
 }
@@ -620,15 +619,9 @@ extension Scheduler {
     }
 
     private func queryOutcomes(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> [Outcome] {
-        var descriptor = FetchDescriptor<Outcome>(
-            predicate: #Predicate { outcome in
-                range.contains(outcome.occurrenceStartDate) && taskPredicate.evaluate(outcome.task)
-            }
-        )
-
-        descriptor.relationshipKeyPathsForPrefetching = [\.task]
-
-        return try context.fetch(descriptor)
+        try context.fetch(FetchDescriptor<Outcome>()).filter { (outcome: Outcome) in
+            try range.contains(outcome.occurrenceStartDate) && taskPredicate.evaluate(outcome.task)
+        }
     }
 
     private func queryTaskIdentifiers(

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -653,6 +653,7 @@ extension Scheduler {
     private func queryOutcomes(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> [Outcome] {
         var descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
+                // swiftlint:disable:next line_length
                 range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
             }
         )
@@ -676,6 +677,7 @@ extension Scheduler {
     private func queryOutcomeIdentifiers(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> Set<PersistentIdentifier> {
         let descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
+                // swiftlint:disable:next line_length
                 range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
             }
         )

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -90,7 +90,7 @@ public final class Scheduler {
     @Dependency(SchedulerNotifications.self)
     private var notifications
 
-    private var _container: Result<ModelContainer, Error>?
+    private var _container: Result<ModelContainer, any Error>?
 
     private var container: ModelContainer {
         get throws {

--- a/Sources/SpeziSchedulerUI/EventScheduleList.swift
+++ b/Sources/SpeziSchedulerUI/EventScheduleList.swift
@@ -117,7 +117,7 @@ public struct EventScheduleList<Tile: View>: View {
                 }
                     .symbolRenderingMode(.multicolor)
             } description: {
-                if let localizedError = fetchError as? LocalizedError,
+                if let localizedError = fetchError as? any LocalizedError,
                    let reason = localizedError.failureReason {
                     Text(reason)
                 } else {

--- a/Sources/SpeziSchedulerUI/TodayList.swift
+++ b/Sources/SpeziSchedulerUI/TodayList.swift
@@ -45,7 +45,7 @@ public struct TodayList<Tile: View>: View {
                 }
                     .symbolRenderingMode(.multicolor)
             } description: {
-                if let localizedError = fetchError as? LocalizedError,
+                if let localizedError = fetchError as? any LocalizedError,
                    let reason = localizedError.failureReason {
                     Text(reason)
                 } else {

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -192,7 +192,7 @@ final class SchedulerTests: XCTestCase {
     
     @MainActor
     func testFetchingEventsAfterCompletion() async throws {
-        let todayRange = Date.today..<Date.tomorrow//.addingTimeInterval(-1)
+        let todayRange = Date.today..<Date.tomorrow
         let module = Scheduler()
         withDependencyResolution {
             module

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -186,7 +186,38 @@ final class SchedulerTests: XCTestCase {
         XCTAssertEqual(components1.minute, 30)
         XCTAssertEqual(components1.second, 49)
 
-
         XCTAssertNoThrow(try module.deleteAllVersions(ofTask: "test-task"))
+    }
+    
+    
+    @MainActor
+    func testFetchingEventsAfterCompletion() async throws {
+        let todayRange = Date.today..<Date.tomorrow//.addingTimeInterval(-1)
+        let module = Scheduler()
+        withDependencyResolution {
+            module
+        }
+        
+        try module.eraseDatabase()
+        XCTAssertTrue(try module.queryAllTasks().isEmpty)
+        XCTAssertTrue(try module.queryAllOutcomes().isEmpty)
+        XCTAssertTrue(try module.queryEvents(for: todayRange).isEmpty)
+        
+        try module.createOrUpdateTask(
+            id: "test-task",
+            title: "Test Task",
+            instructions: "",
+            schedule: .daily(hour: 0, minute: 0, startingAt: .now)
+        )
+        
+        let events = try module.queryEvents(for: todayRange)
+        XCTAssertTrue(events.allSatisfy { todayRange.contains($0.occurrence.start) })
+        XCTAssertEqual(events.count, 1)
+        XCTAssertFalse(try XCTUnwrap(events.first).completed)
+        try XCTUnwrap(events.first).complete()
+        XCTAssertTrue(try XCTUnwrap(events.first).completed)
+        XCTAssertTrue(try XCTUnwrap(try module.queryEvents(for: todayRange).first).completed)
+        try await _Concurrency.Task.sleep(for: .seconds(0.5))
+        XCTAssertTrue(try XCTUnwrap(try module.queryEvents(for: todayRange).first).completed)
     }
 }


### PR DESCRIPTION
# fix `fetchEvents` returning no results; make `Schedule` conform to `Hashable`

## :recycle: Current situation & Problem
- for some reason, the `Scheduler.queryOutcomes` function incorrectly returns an empty array.
  - i have absolutely no idea what exactly is causing this, but it can be fixed by using Swift's `Sequence.filter` function instead passing a `Predicate` to SwiftData
  - this issue can be observed in e.g. the TemplateApplication:
    1. modify the app to include a button somewhere that triggers a view update
    2. launch the app, open and complete the questionnaire scheduled for today
    3. everything looks fine (the scheduled event is marked as completed via a giant green checkmark)
    4. tap the button to trigger a view update
    5. the TodayList will go back to displaying the event as not-yet-completed
  - the issue here is that the next view update will trigger a new call to `queryEvents`, which in turn will call `queryOutcomes`, which will incorrectly return an empty array, even though there are outcomes in the database, which will correctly match the predicate when filtering using `Sequence.filter` instead of via the `Predicate`
- `Schedule` conforms to `Equatable`, but not to `Hashable`


## :gear: Release Notes 
- fix `Event.completed` incorrectly being false in some cases
- made `Schedule` conform to `Hashable`


## :books: Documentation
n/a


## :white_check_mark: Testing
i'm working on adding a test case to make sure completed events are in fact correctly reported as being completed, but since for some reason all of the tests that interact with the `UNUserNotificationCenter` seem to fail when running them locally, this might take a couple of days.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
