### PR TITLE
improve createOrUpdateTask to better handle shadowed outcomes

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -251,6 +251,20 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
                     taskPredicate.evaluate(outcome.task) && outcome.occurrenceStartDate >= effectiveFrom
                 }
             ))
+            guard existingTask.wouldNecessitateNewTaskVersion(
+                title: title,
+                instructions: instructions,
+                category: category,
+                schedule: schedule,
+                completionPolicy: completionPolicy,
+                scheduleNotifications: scheduleNotifications,
+                notificationThread: notificationThread,
+                tags: tags,
+                effectiveFrom: effectiveFrom,
+                with: contextClosure
+            ) else {
+                return (existingTask, false)
+            }
             switch shadowedOutcomesHandling {
             case .throwError:
                 guard outcomesThatWouldBeShadowed.isEmpty else {

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -284,7 +284,8 @@ public final class Task {
     }
     
     
-    func wouldNecessitateNewTaskVersion(
+    /// Determines whether an update of the task, based on the specified parameters, would result in a new version of the task.
+    func wouldNecessitateNewTaskVersion( // swiftlint:disable:this function_parameter_count
         title: String.LocalizationValue?,
         instructions: String.LocalizationValue?,
         category: Category?,
@@ -315,7 +316,7 @@ public final class Task {
             || didChange(context?.userInfo, for: \.userInfo)
     }
 
-    func createUpdatedVersion( // swiftlint:disable:this function_body_length function_parameter_count
+    func createUpdatedVersion( // swiftlint:disable:this function_parameter_count
         skipShadowCheck: Bool,
         title: String.LocalizationValue?,
         instructions: String.LocalizationValue?,

--- a/Tests/UITests/TestApp/ScheduleView.swift
+++ b/Tests/UITests/TestApp/ScheduleView.swift
@@ -18,6 +18,20 @@ enum DateSelection: Hashable {
 }
 
 
+enum AdditionalTestsTestCase: String, CaseIterable, Hashable, Identifiable {
+    case shadowedOutcomes = "Shadowed Outcomes"
+    
+    var id: Self { self }
+    
+    var view: some View {
+        switch self {
+        case .shadowedOutcomes:
+            ShadowedOutcomeTestingView()
+        }
+    }
+}
+
+
 struct ScheduleView: View {
     @Environment(SchedulerModel.self)
     private var model
@@ -26,15 +40,22 @@ struct ScheduleView: View {
     @State private var hidden = false // hide for screenshots
     @State private var dateSelection: DateSelection = .today
     @State private var date = Date()
+    @State private var additionalTestsTestCase: AdditionalTestsTestCase?
 
     var body: some View {
         @Bindable var model = model
         NavigationStack {
             scheduleList
                 .navigationTitle("Schedule")
+                .navigationBarTitleDisplayMode(.inline)
                 .viewStateAlert(state: $model.viewState)
                 .toolbar {
-                    toolbar
+                    if !hidden {
+                        toolbar
+                    }
+                }
+                .sheet(item: $additionalTestsTestCase) { testCase in
+                    testCase.view
                 }
                 .onChange(of: dateSelection, initial: true) {
                     switch dateSelection {
@@ -64,22 +85,29 @@ struct ScheduleView: View {
     }
 
     @ToolbarContentBuilder private var toolbar: some ToolbarContent {
-        ToolbarItemGroup(placement: .secondaryAction) {
-            if !hidden {
-                Picker("Alignment", selection: $alignment) {
-                    Text("Leading").tag(HorizontalAlignment.leading)
-                    Text("Center").tag(HorizontalAlignment.center)
-                    Text("Trailing").tag(HorizontalAlignment.trailing)
+        ToolbarItem(placement: .topBarLeading) {
+            Menu("Extra Tests") {
+                ForEach(AdditionalTestsTestCase.allCases, id: \.self) { testCase in
+                    Button(testCase.rawValue) {
+                        additionalTestsTestCase = testCase
+                    }
                 }
-
-                Picker("Date", selection: $dateSelection) {
-                    Text("Today").tag(DateSelection.today)
-                    Text("Tomorrow").tag(DateSelection.tomorrow)
-                    Text("Date").tag(DateSelection.date)
-                }
-
-                Button("Hide Content", action: hide)
             }
+        }
+        ToolbarItemGroup(placement: .secondaryAction) {
+            Picker("Alignment", selection: $alignment) {
+                Text("Leading").tag(HorizontalAlignment.leading)
+                Text("Center").tag(HorizontalAlignment.center)
+                Text("Trailing").tag(HorizontalAlignment.trailing)
+            }
+
+            Picker("Date", selection: $dateSelection) {
+                Text("Today").tag(DateSelection.today)
+                Text("Tomorrow").tag(DateSelection.tomorrow)
+                Text("Date").tag(DateSelection.date)
+            }
+
+            Button("Hide Content", action: hide)
         }
     }
 

--- a/Tests/UITests/TestApp/ShadowedOutcomeTestingView.swift
+++ b/Tests/UITests/TestApp/ShadowedOutcomeTestingView.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Spezi
+import SpeziScheduler
+import SwiftUI
+import XCTestApp
+
+
+struct ShadowedOutcomeTestingView: View { // swiftlint:disable:this file_types_order
+    @Environment(\.calendar)
+    private var cal
+    @Environment(Scheduler.self)
+    private var scheduler
+    
+    var body: some View {
+        TestAppView(testCase: TestCase(cal: cal, scheduler: scheduler))
+    }
+}
+
+
+private struct TestCase: TestAppTestCase {
+    let cal: Calendar
+    let scheduler: Scheduler
+    
+    func runTests() throws {
+        let registerTask = {
+            try self.scheduler.createOrUpdateTask(
+                id: "shadowed-outcomes-testing-task",
+                title: "Shadowed Outcomes Testing Task",
+                instructions: "",
+                schedule: .daily(hour: 23, minute: 59, startingAt: .today)
+            ).task
+        }
+        let task = try registerTask()
+        let events = try scheduler.queryEvents(for: task, in: cal.rangeOfWeek(for: cal.startOfNextWeek(for: .now)))
+        for event in events.dropFirst(2) {
+            try event.complete(ignoreCompletionPolicy: true)
+        }
+        try XCTAssertNoThrow(try registerTask())
+    }
+}

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -191,6 +191,24 @@ class TestAppUITests: XCTestCase {
             nextTriggerExistenceTimeout: 60
         )
     }
+    
+    
+    @MainActor
+    func testShadowedOutcomesHandlingWhenReRegisteringSameTask() throws {
+        let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+
+        XCTAssert(app.wait(for: .runningForeground, timeout: 2.0))
+        
+        let menuButton = app.buttons["Extra Tests"]
+        XCTAssert(menuButton.waitForExistence(timeout: 2))
+        menuButton.tryToTapReallySoftlyMaybeThisWillMakeItWork()
+        let testCaseButton = app.buttons["Shadowed Outcomes"]
+        XCTAssert(testCaseButton.waitForExistence(timeout: 2))
+        testCaseButton.tap()
+        
+        XCTAssertTrue(app.staticTexts["Passed"].waitForExistence(timeout: 2))
+    }
 }
 
 
@@ -200,5 +218,17 @@ extension XCUIApplication {
         XCTAssert(tab.waitForExistence(timeout: 2.0), line: line)
         tab.tap()
         tab.tap()
+    }
+}
+
+extension XCUIElement {
+    // This is required to work around an apparent XCTest bug when trying to tap e.g. the Health App's Profile button.
+    // See also: https://stackoverflow.com/a/33534187
+    func tryToTapReallySoftlyMaybeThisWillMakeItWork() {
+        if isHittable {
+            tap()
+        } else {
+            coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		2FE0B6EA2A14D82600818AE9 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FE0B6E92A14D82600818AE9 /* XCTestExtensions */; };
 		80328A752D6CE4E60050ECB6 /* XCTSpeziNotifications in Frameworks */ = {isa = PBXBuildFile; productRef = 80328A742D6CE4E60050ECB6 /* XCTSpeziNotifications */; };
 		80328A772D6CE4E60050ECB6 /* XCTSpeziNotificationsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 80328A762D6CE4E60050ECB6 /* XCTSpeziNotificationsUI */; };
+		805BAA032D79C23A00115B39 /* ShadowedOutcomeTestingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805BAA022D79C23A00115B39 /* ShadowedOutcomeTestingView.swift */; };
+		805BAA052D79C2E700115B39 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 805BAA042D79C2E700115B39 /* XCTestApp */; };
 		A926A5352C9D87B100C92F94 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A926A5342C9D87B100C92F94 /* NotificationsView.swift */; };
 		A977F6732C92F4C00071A1D1 /* SpeziSchedulerUI in Frameworks */ = {isa = PBXBuildFile; productRef = A977F6722C92F4C00071A1D1 /* SpeziSchedulerUI */; };
 		A98B09C42C90913F0076E99A /* TestAppScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98B09C32C9091390076E99A /* TestAppScheduler.swift */; };
@@ -43,6 +45,7 @@
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 		2FE0B6E52A14C64E00818AE9 /* SpeziScheduler */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziScheduler; path = ../..; sourceTree = "<group>"; };
+		805BAA022D79C23A00115B39 /* ShadowedOutcomeTestingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowedOutcomeTestingView.swift; sourceTree = "<group>"; };
 		A926A5342C9D87B100C92F94 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
 		A960461B2C9840E800EA8022 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A960461C2C9853C700EA8022 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
@@ -59,6 +62,7 @@
 			files = (
 				2F68C3C8292EA52000B3E12C /* Spezi in Frameworks */,
 				80328A772D6CE4E60050ECB6 /* XCTSpeziNotificationsUI in Frameworks */,
+				805BAA052D79C2E700115B39 /* XCTestApp in Frameworks */,
 				A977F6732C92F4C00071A1D1 /* SpeziSchedulerUI in Frameworks */,
 				2FE0B6E72A14C65900818AE9 /* SpeziScheduler in Frameworks */,
 			);
@@ -109,6 +113,7 @@
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F9F4D8429B80A1500ABE259 /* TestAppDelegate.swift */,
 				A98B09C32C9091390076E99A /* TestAppScheduler.swift */,
+				805BAA022D79C23A00115B39 /* ShadowedOutcomeTestingView.swift */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 			);
 			path = TestApp;
@@ -150,6 +155,7 @@
 				2FE0B6E62A14C65900818AE9 /* SpeziScheduler */,
 				A977F6722C92F4C00071A1D1 /* SpeziSchedulerUI */,
 				80328A762D6CE4E60050ECB6 /* XCTSpeziNotificationsUI */,
+				805BAA042D79C2E700115B39 /* XCTestApp */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -248,6 +254,7 @@
 				A98B09C42C90913F0076E99A /* TestAppScheduler.swift in Sources */,
 				A9C2951D2C899FA10038EF1B /* ScheduleView.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
+				805BAA032D79C23A00115B39 /* ShadowedOutcomeTestingView.swift in Sources */,
 				A926A5352C9D87B100C92F94 /* NotificationsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -599,6 +606,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 80328A732D6CE4E60050ECB6 /* XCRemoteSwiftPackageReference "SpeziNotifications" */;
 			productName = XCTSpeziNotificationsUI;
+		};
+		805BAA042D79C2E700115B39 /* XCTestApp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2FE0B6E82A14D82600818AE9 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			productName = XCTestApp;
 		};
 		A977F6722C92F4C00071A1D1 /* SpeziSchedulerUI */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
# improve createOrUpdateTask

## :recycle: Current situation & Problem
This PR adds an extra check in `createOrUpdateTask` which, in the case of updating an already-existing task, will perform an early return if the update would leave the task unchanged. The old version also had this type of check, but it was only performed after the shadowed outcome handling, meaning that in a situation where there were shadowed outcomes but the task would not need to be updated, the fact that there were shadowed outcomes would take precedence (simply because the check was performed earlier) and the function would unnecessarily throw an error.

## :gear: Release Notes 
- improve `createOrUpdateTask` to better handle shadowed outcomes

## :books: Documentation
n/a

## :white_check_mark: Testing
regression test will be added before the PR is merged

## :pencil: Code of Conduct & Contributing Guidelines 
By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
