### PR TITLE
Add Documentation Example for Notification

### DIFF
--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -67,7 +67,7 @@ import struct SwiftUI.AppStorage
 ///
 /// ### Notifications for Completed Events
 /// 
-/// When notifications are enabled, the app will send alerts based on the task’s schedule. 
+/// When notifications are enabled in a task, the app will send alerts based on the task’s schedule. 
 /// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
 /// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
 ///

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -29,7 +29,7 @@ import struct SwiftUI.AppStorage
 /// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
 /// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
 ///
-/// Below is an example of how to schedule a task with notifications and selectively disable notifications for certain events:
+/// You can schedule a ``Task`` with notifications and selectively disable notifications for certain ``Event``s:
 ///
 /// ```swift
 /// // Step 1: Schedule a recurring task with notifications

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -66,17 +66,17 @@ import struct SwiftUI.AppStorage
 ///     you requested notification authorization from the user. Otherwise, SpeziScheduler won't schedule notifications properly.
 ///
 /// ### Notifications for Completed Events
-/// 
-/// When notifications are enabled in a task, the app will send alerts based on the task’s schedule. 
-/// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
-/// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
 ///
-/// You can schedule a ``Task`` with notifications and selectively disable notifications for certain ``Event``s.
+/// When notifications are enabled for a task, the Spezi Scheduler module sends alerts based on the task’s schedule.
+/// However, it does **not** send notifications for ``Event``s that have already been marked as complete.
+/// Other scheduled ``Event``s will continue to trigger notifications as expected.
 ///
-/// First, create a task that triggers notifications on a daily schedule:
+/// To prevent notifications for a specific event, call ``Event/complete()`` to mark that event as complete.
 ///
+/// You can schedule a ``Task`` with notifications enabled and selectively disable notifications for individual ``Event``s as needed.
+///
+/// #### 1. Create or update a recurring task with daily notifications
 /// ```swift
-/// // Schedule a recurring task with notifications
 /// try scheduler.createOrUpdateTask(
 ///     id: "task-id",
 ///     title: "Daily Task Reminder",
@@ -87,12 +87,13 @@ import struct SwiftUI.AppStorage
 /// )
 /// ```
 ///
-/// If you want to stop notifications for specific future events, you can mark those events as complete:
+/// #### 2. Disable notifications for specific upcoming events by marking them as complete
+///
+/// You can define a function to preemptively complete a set of upcoming events, preventing notifications from being triggered by the Spezi Scheduler or other application logic.
+/// The example below marks all relevant ``Event``s as complete for the specified number of days ahead:
 /// ```swift
-/// // Mark upcoming events as complete to stop notifications
-/// // Suppose you want to disable notifications for the next `daysAhead` days, you can complete those events in advance.
 /// @MainActor
-/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) throws {
+/// func completeAllEvents(for taskID: String, daysAhead: Int) throws {
 ///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: .now) else { return }
 ///
 ///     let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
@@ -101,7 +102,6 @@ import struct SwiftUI.AppStorage
 ///     }
 /// }
 /// ```
-/// You can call this function whenever a condition is met to disable notifications for the next few days.
 ///
 ///
 /// ## Topics

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -24,42 +24,6 @@ import struct SwiftUI.AppStorage
 ///
 /// Notifications can be automatically scheduled for Tasks that are scheduled using the ``Scheduler`` module. You configure a Task for automatic notification scheduling by
 /// setting the ``Task/scheduleNotifications`` property.
-/// 
-/// When notifications are enabled, the app will send alerts based on the task’s schedule. 
-/// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
-/// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
-///
-/// You can schedule a ``Task`` with notifications and selectively disable notifications for certain ``Event``s:
-///
-/// ```swift
-/// // Step 1: Schedule a recurring task with notifications
-/// try scheduler.createOrUpdateTask(
-///     id: "task-id",
-///     title: "Daily Task Reminder",
-///     instructions: "Remember to complete your daily task!",
-///     category: .questionnaire,
-///     schedule: .daily(hour: 9, minute: 0, startingAt: .today),
-///     scheduleNotifications: true
-/// )
-///
-/// // Step 2: Mark upcoming events as complete to stop notifications
-/// // Suppose you want to disable notifications for the next `daysAhead` days, you can complete those events in advance.
-/// @MainActor
-/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) throws {
-///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: .now) else { return }
-///
-///     let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
-///     for event in events {
-///         try event.complete()
-///     }
-/// }
-///
-/// // Step 3: Call this function whenever you want to disable notifications for upcoming events
-/// // For example, if a condition is met, disable notifications for the next 7 days:
-/// if condition == true {
-///     disableNotificationForEvent(for: "task-id", daysAhead: 7)
-/// }
-/// ```
 ///
 /// - Note: The `SchedulerNotifications` module is automatically configured by the `Scheduler` module using default configuration options. If you want to
 ///     customize the configuration, just provide the configured module in your `configuration` section of your
@@ -100,6 +64,45 @@ import struct SwiftUI.AppStorage
 ///
 /// - Important: If you disable ``automaticallyRequestProvisionalAuthorization``, make sure to call ``Scheduler/manuallyScheduleNotificationRefresh()`` once
 ///     you requested notification authorization from the user. Otherwise, SpeziScheduler won't schedule notifications properly.
+///
+/// ### Notifications for Completed Events
+/// 
+/// When notifications are enabled, the app will send alerts based on the task’s schedule. 
+/// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
+/// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
+///
+/// You can schedule a ``Task`` with notifications and selectively disable notifications for certain ``Event``s.
+///
+/// First, create a task that triggers notifications on a daily schedule:
+///
+/// ```swift
+/// // Schedule a recurring task with notifications
+/// try scheduler.createOrUpdateTask(
+///     id: "task-id",
+///     title: "Daily Task Reminder",
+///     instructions: "Remember to complete your daily task!",
+///     category: .questionnaire,
+///     schedule: .daily(hour: 9, minute: 0, startingAt: .today),
+///     scheduleNotifications: true
+/// )
+/// ```
+///
+/// If you want to stop notifications for specific future events, you can mark those events as complete:
+/// ```swift
+/// // Mark upcoming events as complete to stop notifications
+/// // Suppose you want to disable notifications for the next `daysAhead` days, you can complete those events in advance.
+/// @MainActor
+/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) throws {
+///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: .now) else { return }
+///
+///     let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
+///     for event in events {
+///         try event.complete()
+///     }
+/// }
+/// ```
+/// You can call this function whenever a condition is met to disable notifications for the next few days.
+///
 ///
 /// ## Topics
 ///

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -26,8 +26,8 @@ import struct SwiftUI.AppStorage
 /// setting the ``Task/scheduleNotifications`` property.
 /// 
 /// When notifications are enabled, the app will send alerts based on the task’s schedule. 
-///     If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
-///     This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
+/// If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
+/// This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
 ///
 /// Below is an example of how to schedule a task with notifications and selectively disable notifications for certain events:
 ///

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -24,6 +24,48 @@ import struct SwiftUI.AppStorage
 ///
 /// Notifications can be automatically scheduled for Tasks that are scheduled using the ``Scheduler`` module. You configure a Task for automatic notification scheduling by
 /// setting the ``Task/scheduleNotifications`` property.
+/// 
+/// When notifications are enabled, the app will send alerts based on the task’s schedule. 
+///     If you want to stop notifications for a specific event, you can call ``Event/complete()`` to mark the event as complete.
+///     This will prevent notifications only for that particular occurrence, while other events will still trigger notifications as scheduled.
+///
+/// Below is an example of how to schedule a task with notifications and selectively disable notifications for certain events:
+///
+/// ```swift
+/// // Step 1: Schedule a recurring task with notifications
+/// try scheduler.createOrUpdateTask(
+///     id: "task-id",
+///     title: "Daily Task Reminder",
+///     instructions: "Remember to complete your daily task!",
+///     category: .questionnaire,
+///     schedule: .daily(hour: 9, minute: 0, startingAt: .today),
+///     scheduleNotifications: true
+/// )
+///
+/// // Step 2: Mark upcoming events as complete to stop notifications
+/// // Suppose you want to disable notifications for the next `daysAhead` days, you can complete those events in advance.
+/// @MainActor
+/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) {
+///     let today = Date()
+///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: today) else { return }
+///
+///     do {
+///         let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
+///         for event in events {
+///             try event.complete()
+///             print("Marked event on \(event.occurrence.start) as complete. Notification disabled for this event.")
+///         }
+///     } catch {
+///         print("Error completing events: \(error)")
+///     }
+/// }
+///
+/// // Step 3: Call this function whenever you want to disable notifications for upcoming events
+/// // For example, if a condition is met, disable notifications for the next 7 days:
+/// if condition == true {
+///     disableNotificationForEvent(for: "task-id", daysAhead: 7)
+/// }
+/// ```
 ///
 /// - Note: The `SchedulerNotifications` module is automatically configured by the `Scheduler` module using default configuration options. If you want to
 ///     customize the configuration, just provide the configured module in your `configuration` section of your

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -45,18 +45,12 @@ import struct SwiftUI.AppStorage
 /// // Step 2: Mark upcoming events as complete to stop notifications
 /// // Suppose you want to disable notifications for the next `daysAhead` days, you can complete those events in advance.
 /// @MainActor
-/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) {
-///     let today = Date()
-///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: today) else { return }
+/// func disableNotificationForEvent(for taskID: String, daysAhead: Int) throws {
+///     guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: .now) else { return }
 ///
-///     do {
-///         let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
-///         for event in events {
-///             try event.complete()
-///             print("Marked event on \(event.occurrence.start) as complete. Notification disabled for this event.")
-///         }
-///     } catch {
-///         print("Error completing events: \(error)")
+///     let events = try scheduler.queryEvents(for: today..<endDate, predicate: #Predicate { $0.id == taskID })
+///     for event in events {
+///         try event.complete()
 ///     }
 /// }
 ///

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -70,6 +70,7 @@ class TestAppUITests: XCTestCase {
         checkButtonExists("Complete Measurement")
         checkButtonExists("Complete Questionnaire")
         checkButtonExists("Complete Enter Lab Results")
+        app.buttons["Complete Enter Lab Results"].tap()
         
         goToTab("Notifications")
 


### PR DESCRIPTION
# *Add Documentation Example for Notification*

## :recycle: Current situation & Problem
I'm a student from CS342. In my project, I encountered challenges when using `SpeziScheduler` for notifications. I struggled to figure out how to send notifications and, more importantly, how to stop notifications for specific future events without affecting the entire schedule.

I realized that for many digital health apps, handling notifications dynamically — like disabling future reminders after a user action — is a common scenario. However, the existing `SpeziScheduler` documentation lacked sample code for handling these cases, making it hard to understand how to implement this feature.

This PR adds a clear, step-by-step example to the SchedulerNotifications section, showing how to:

* Enable notifications for scheduled tasks
* Mark future events as complete to cancel notifications only for those events (while keeping others intact)

I believe this improvement will make it much easier for developers to leverage SpeziScheduler for notification-based features!


## :gear: Release Notes
* Added Documentation Example in `SchedulerNotifications` section: Added sample code to show how to use `createOrUpdateTask` with notifications and selectively disable notifications for specific events by marking them as complete.

## :books: Documentation
Updated DocC Documentation: Extended the `SchedulerNotifications` section to include the new example.


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
