### PR TITLE
avoid unnecessarily creating new task versions in some cases

### DIFF
--- a/Sources/SpeziScheduler/UserInfo/UserStorageCoding.swift
+++ b/Sources/SpeziScheduler/UserInfo/UserStorageCoding.swift
@@ -54,7 +54,14 @@ public struct UserStorageCoding<Encoder: TopLevelEncoder & Sendable, Decoder: To
 
 extension UserStorageCoding where Encoder == JSONEncoder, Decoder == JSONDecoder {
     /// JSON encoder and decoder.
-    public static let json = UserStorageCoding(encoder: JSONEncoder(), decoder: JSONDecoder())
+    public static let json = UserStorageCoding(
+        encoder: { () -> JSONEncoder in
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            return encoder
+        }(),
+        decoder: JSONDecoder()
+    )
 }
 
 

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -218,6 +218,7 @@ final class SchedulerTests: XCTestCase {
                 with: { context in
                     context.nonTrivialExample = value
                 }
+            )
         }
         
         XCTAssertTrue(try createTask().didChange)

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -189,6 +189,41 @@ final class SchedulerTests: XCTestCase {
         XCTAssertNoThrow(try module.deleteAllVersions(ofTask: "test-task"))
     }
     
+    @MainActor
+    func testNonTrivialTaskContextCoding() throws {
+        let module = Scheduler()
+        withDependencyResolution {
+            module
+        }
+        
+        let value = NonTrivialTaskContext(
+            field0: .random(in: 0..<100),
+            field1: .random(in: 0..<100),
+            field2: .random(in: 0..<100),
+            field3: .random(in: 0..<100),
+            field4: .random(in: 0..<100),
+            field5: .random(in: 0..<100),
+            field6: .random(in: 0..<100),
+            field7: .random(in: 0..<100),
+            field8: .random(in: 0..<100),
+            field9: .random(in: 0..<100)
+        )
+        
+        let createTask = {
+            try module.createOrUpdateTask(
+                id: #function,
+                title: "Title",
+                instructions: "Instructions",
+                schedule: Schedule.daily(hour: 7, minute: 41, startingAt: .now),
+                with: { context in
+                    context.nonTrivialExample = value
+                }
+        }
+        
+        XCTAssertTrue(try createTask().didChange)
+        XCTAssertFalse(try createTask().didChange)
+    }
+    
     
     @MainActor
     func testFetchingEventsAfterCompletion() async throws {

--- a/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
+++ b/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
@@ -9,6 +9,21 @@
 import SpeziScheduler
 
 
+struct NonTrivialTaskContext: Codable {
+    // give it a bunch of fields to maximise the likelihood of something being out of order
+    let field0: Int
+    let field1: Int
+    let field2: Int
+    let field3: Int
+    let field4: Int
+    let field5: Int
+    let field6: Int
+    let field7: Int
+    let field8: Int
+    let field9: Int
+}
+
+
 extension Outcome {
     @Property var example: String?
 }
@@ -21,4 +36,8 @@ extension Task.Context {
 
 extension Task.Context {
     @Property var example2: String = "Hello World"
+}
+
+extension Task.Context {
+    @Property(coding: .json) var nonTrivialExample: NonTrivialTaskContext?
 }

--- a/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
+++ b/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
@@ -39,5 +39,6 @@ extension Task.Context {
 }
 
 extension Task.Context {
-    @Property(coding: .json) var nonTrivialExample: NonTrivialTaskContext?
+    @Property(coding: .json)
+    var nonTrivialExample: NonTrivialTaskContext?
 }

--- a/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
+++ b/Tests/SpeziSchedulerTests/Utils/ExampleTaskKey.swift
@@ -9,7 +9,7 @@
 import SpeziScheduler
 
 
-struct NonTrivialTaskContext: Codable {
+struct NonTrivialTaskContext: Hashable, Codable {
     // give it a bunch of fields to maximise the likelihood of something being out of order
     let field0: Int
     let field1: Int


### PR DESCRIPTION
# avoid unnecessarily creating new task versions in some cases

## :recycle: Current situation & Problem
The `createOrUpdateTask` function operates by looking at the parameter it is passed and comparing them to the properties of the current version of the task with a matching id, to determine whether the task needs to be updated (ie, whether we need to create a new version). These comparisons also include the task's context, which is compared by looking at its internal `[String: Data]` representation, where each entry maps a context property name to its value's encoded representation.
This comparison works fine for trivial context values (eg `@Property var value: Int?` or `@Property var value: String?`), since in these cases all values will have a single encoded representation. However, for non-trivial types, this is no longer the case. For example, if we have `@Property(coding: .json) var value: Person?`, where `Person` is a struct with multiple properties, each value of the struct will have multiple potential encoded representations (one for each order in which the struct's properties are encoded into the JSON dict). This then ends up breaking our comparison logic, leading to the `createOrUpdateTask` function unnecessarily creating duplicate Task versions.

Since the task's context will be encoded into a fully untyped dictionary (the `[String: Data]` mentioned above) we sadly can't do a runtime-type-introspection-based proper equality comparison, which would solve this problem entirely. Instead, we attempt to at least mitigate it by configuring the `JSONEncoder` used by the `@Property(coding: .json)` macro to emit sorted keys when formatting its output. This doesn't fully fix this issue, since a type encoded into a task context could still have a custom `encode` function (or could contain a (potentially nested) property of a type with a custom `encode` function) which doesn't respect the sorting option. However, this should at least increase the likelihood of two task context properties with equal values also having equal encoded representations.


## :gear: Release Notes
- improved `createOrUpdateTask` to avoid unnecessarily creating new task versions in some cases


## :books: Documentation
n/a


## :white_check_mark: Testing
there is a regression test


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
