### PR TITLE
update swift-syntax; some other Package.swift changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,13 +27,13 @@ let package = Package(
         .library(name: "SpeziSchedulerUI", targets: ["SpeziSchedulerUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.3"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.7.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.10.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.1.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNotifications.git", from: "1.0.5"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0-prerelease-2024-08-14"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2")
     ] + swiftLintPackage(),
     targets: [
@@ -91,6 +91,7 @@ let package = Package(
                 .product(name: "XCTSpezi", package: "Spezi"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
+            resources: [.process("__Snapshots__")],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),


### PR DESCRIPTION
# update swift-syntax; some other Package.swift changes

## :recycle: Current situation & Problem
This PR:
- updates swift-syntax from `600.0.0-prerelease-2024-08-14` to `601.0.1`
- updates SpeziFoundation and SpeziViews
- explicitly adds a the test target's `__Snapshots__` folder to the package manifest


## :gear: Release Notes
- updated the swift-syntax dependency to the one for Swift 6.1


## :books: Documentation
n/a


## :white_check_mark: Testing
the tests (especially the macro-related ones) still pass.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
