### PR TITLE
Scheduler persistence control; relax the swift-syntax requirement from `>=601.0.1` to `>=601.0.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.1.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNotifications.git", from: "1.0.5"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2")
     ] + swiftLintPackage(),
     targets: [

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -141,14 +141,14 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
         case .onDisk:
             _container = Result {
                 try ModelContainer(
-                    for: Task.self, Outcome.self,
+                    for: Task.self, Outcome.self, // swiftlint:disable:this multiline_arguments
                     configurations: ModelConfiguration(url: URL.documentsDirectory.appending(path: "edu.stanford.spezi.scheduler.storage.sqlite"))
                 )
             }
         case .inMemory:
             _container = Result {
                 try ModelContainer(
-                    for: Task.self, Outcome.self,
+                    for: Task.self, Outcome.self, // swiftlint:disable:this multiline_arguments
                     configurations: ModelConfiguration(isStoredInMemoryOnly: true)
                 )
             }

--- a/Sources/SpeziSchedulerUI/TestingSupport/SchedulerSampleData.swift
+++ b/Sources/SpeziSchedulerUI/TestingSupport/SchedulerSampleData.swift
@@ -59,7 +59,7 @@ public struct SchedulerSampleData: PreviewModifier {
         content
             .taskCategoryAppearance(for: .questionnaire, label: "Questionnaire", image: .system("list.bullet.clipboard"))
             .previewWith {
-                Scheduler(testingContainer: context)
+                Scheduler(persistence: .testingContainer(context))
             }
     }
 }

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -15,16 +15,9 @@ import XCTSpezi
 
 final class SchedulerTests: XCTestCase {
     @MainActor
-    override func setUp() async throws {
-#if os(macOS)
-        Scheduler.isTesting = true
-#endif
-    }
-
-    @MainActor
     func testScheduler() {
         // test simple scheduler initialization test
-        let module = Scheduler()
+        let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
         }
@@ -44,7 +37,7 @@ final class SchedulerTests: XCTestCase {
 
     @MainActor
     func testSimpleTaskCreation() throws {
-        let module = Scheduler()
+        let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
         }
@@ -83,7 +76,7 @@ final class SchedulerTests: XCTestCase {
 
     @MainActor
     func testSimpleTaskVersioning() throws { // swiftlint:disable:this function_body_length
-        let module = Scheduler()
+        let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
         }
@@ -191,7 +184,7 @@ final class SchedulerTests: XCTestCase {
     
     @MainActor
     func testNonTrivialTaskContextCoding() throws {
-        let module = Scheduler()
+        let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
         }
@@ -229,7 +222,7 @@ final class SchedulerTests: XCTestCase {
     @MainActor
     func testFetchingEventsAfterCompletion() async throws {
         let todayRange = Date.today..<Date.tomorrow
-        let module = Scheduler()
+        let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
         }

--- a/Tests/SpeziSchedulerUITests/SchedulerSampleDataTests.swift
+++ b/Tests/SpeziSchedulerUITests/SchedulerSampleDataTests.swift
@@ -19,7 +19,7 @@ final class SchedulerSampleDataTests: XCTestCase {
     func testSchedulerSampleData() throws {
         let container = try SchedulerSampleData.makeSharedContext()
 
-        let scheduler = Scheduler(testingContainer: container)
+        let scheduler = Scheduler(persistence: .testingContainer(container))
         withDependencyResolution {
             scheduler
         }


### PR DESCRIPTION
# Scheduler persistence control; relax the swift-syntax requirement from `>=601.0.1` to `>=601.0.0`

## :recycle: Current situation & Problem
#66 updated the swift-syntax dependency to requiring at least version 601.0.1, which is incompatible with the latest SwiftLint release, which requires exactly 601.0.0.
This isn't an issue when compiling the SpeziScheduler package on its own, or using it in an app that doesn't use the SwiftLint plug in; but when using the plug in this causes the package resolution to fail.
This PR attempts to fix this.

Additionally, this PR updates the `Scheduler` module's API to allow explicitly specifying how the Scheduler should persist its data.
Previously, the Scheduler would decide this on its own, based on the following schema:
- if the app is running in the iOS Simulator, or in a TEST configuration
    - → use in-memory persistence
- if the app is running on macOS, and the Scheduler's static `isTesting` property is set to `true` at the time the module's configure() function is called
    - → use in-memory persistence
- if the Scheduler is created using its `init(testingContainer:)` initializer (which was `@_spi(TestingSupport)`-constrained):
    - → use that `ModelContainer` and assume that everything will work fine
- in all other cases:
    - → use an on-disk SwiftData ModelContainer
None of this was documented (including the fact that simulator builds would always implicitly use an in-memory database), and there have been several occasions where students participating in the CS342 course thought that their code was wrong, whereas the actual issue was that they were running their app in the simulator, and no scheduled tasks were actually persisted.

We now have a new API, which consists of an enum with cases for `onDisk` and `inMemory`, as well as a special `testingContainer(ModelContainer)` case (which is hidden behind the TestingSupport SPI), and a new `init(persistence:)` on the Scheduler, which allows apps to control how the Scheduler should persist its tasks and outcomes.
The Scheduler is still default-initializable, and defaults to `onDisk` persistence.


## :gear: Release Notes
- relaxed swift-syntax requirement to restore SwiftLint compatibility
- added a `Scheduler.init(persistence:)` initializer, allowing apps control over how exactly the Scheduler should store its data.


## :books: Documentation
The new persistence config API is documented.


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
