### PR TITLE
[macOS] prevent escaping the sandbox

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         .library(name: "SpeziSchedulerUI", targets: ["SpeziSchedulerUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.3"),
+//        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.3"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", branch: "lukas/platform-env-detection"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.10.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,7 @@ let package = Package(
         .library(name: "SpeziSchedulerUI", targets: ["SpeziSchedulerUI"])
     ],
     dependencies: [
-//        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", branch: "lukas/platform-env-detection"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.1.4"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.10.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "2.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,8 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziNotifications.git", from: "1.0.6"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2")
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.2"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.3")
     ] + swiftLintPackage(),
     targets: [
         .macro(
@@ -52,12 +53,13 @@ let package = Package(
             name: "SpeziScheduler",
             dependencies: [
                 .target(name: "SpeziSchedulerMacros"),
-                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .product(name: "Spezi", package: "Spezi"),
+                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .product(name: "SpeziViews", package: "SpeziViews"),
                 .product(name: "SpeziNotifications", package: "SpeziNotifications"),
                 .product(name: "SpeziLocalStorage", package: "SpeziStorage"),
-                .product(name: "Algorithms", package: "swift-algorithms")
+                .product(name: "Algorithms", package: "swift-algorithms"),
+                .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
@@ -79,7 +81,8 @@ let package = Package(
             dependencies: [
                 .target(name: "SpeziScheduler"),
                 .product(name: "XCTSpezi", package: "Spezi"),
-                .product(name: "SpeziLocalStorage", package: "SpeziStorage")
+                .product(name: "SpeziLocalStorage", package: "SpeziStorage"),
+                .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -12,6 +12,7 @@ import Spezi
 import SwiftData
 import SpeziFoundation
 import SwiftUI
+import XCTRuntimeAssertions
 
 
 /// Schedule and query tasks and their events.

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 import Spezi
 import SwiftData
+import SpeziFoundation
 import SwiftUI
 
 
@@ -136,9 +137,20 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
     }
     
     /// Creates a new Scheduler, using the specified persistence configuration.
-    public nonisolated init(persistence: PersistenceConfiguration = .onDisk) {
+    public nonisolated init(persistence: PersistenceConfiguration) {
         switch persistence {
         case .onDisk:
+            guard ProcessInfo.isRunningInSandbox else {
+                preconditionFailure(
+                    """
+                    The current application is running in a non-sandboxed environment.
+                    In this case, the `onDisk` persistence configuration is not available,
+                    since the \(Scheduler.self) module would end up placing its database directly into
+                    the current user's Documents directory (i.e., `~/Documents`).
+                    Specify another persistence option, or enable sandboxing for the application.
+                    """
+                )
+            }
             _container = Result {
                 try ModelContainer(
                     for: Task.self, Outcome.self, // swiftlint:disable:this multiline_arguments

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -9,8 +9,8 @@
 import Combine
 import Foundation
 import Spezi
-import SwiftData
 import SpeziFoundation
+import SwiftData
 import SwiftUI
 import XCTRuntimeAssertions
 

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -24,7 +24,7 @@ import XCTRuntimeAssertions
 /// for tasks. It allows to modify the properties (e.g., schedule) of future events without affecting occurrences of the past.
 ///
 /// You create and automatically update your tasks
-/// using ``createOrUpdateTask(id:title:instructions:category:schedule:completionPolicy:scheduleNotifications:notificationThread:tags:effectiveFrom:with:)``.
+/// using ``createOrUpdateTask(id:title:instructions:category:schedule:completionPolicy:scheduleNotifications:notificationThread:tags:effectiveFrom:shadowedOutcomesHandling:with:)``.
 ///
 /// Below is a example on how to create your own [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module)
 /// to manage your tasks and ensure they are always up to date.
@@ -55,13 +55,15 @@ import XCTRuntimeAssertions
 /// }
 /// ```
 ///
+/// - Note: When using the `Scheduler` in a macOS application, your app needs to be sandboxed if you want to use the ``PersistenceConfiguration/onDisk`` persistance option.
+///
 /// ## Topics
 ///
 /// ### Configuration
 /// - ``init()``
 ///
 /// ### Creating and Updating Tasks
-/// - ``createOrUpdateTask(id:title:instructions:category:schedule:completionPolicy:scheduleNotifications:notificationThread:tags:effectiveFrom:with:)``
+/// - ``createOrUpdateTask(id:title:instructions:category:schedule:completionPolicy:scheduleNotifications:notificationThread:tags:effectiveFrom:shadowedOutcomesHandling:with:)``
 ///
 /// ### Query Tasks
 /// - ``queryTasks(for:predicate:sortBy:fetchLimit:prefetchOutcomes:)-8z86i``
@@ -71,7 +73,7 @@ import XCTRuntimeAssertions
 /// - ``queryEvents(for:predicate:)``
 ///
 /// ### Permanently delete a Task version
-/// - ``deleteTasks(_:)-5n7iv``
+/// - ``deleteTasks(_:)-9jjbl``
 /// - ``deleteTasks(_:)-8h2bj``
 ///
 /// ### Permanently delete all Task versions

--- a/Sources/SpeziScheduler/Task/AllowedCompletionPolicy.swift
+++ b/Sources/SpeziScheduler/Task/AllowedCompletionPolicy.swift
@@ -73,7 +73,7 @@ extension AllowedCompletionPolicy {
     /// Retrieve the date at which the result of `isAllowedToComplete` changes back to disallowed.
     /// - Parameters:
     ///   - event: The event.
-    ///   - date: The date that is considered as the `now` date.
+    ///   - now: The date that is considered as the "now" date.
     /// - Returns: Returns the date at which the event is no longer allowed to be completed, if it is in the future, otherwise `nil`.
     ///     For ``AllowedCompletionPolicy/anytime``, this function returns `Date.distantFuture`.
     public func dateOnceCompletionBecomesDisallowed(for event: Event, now: Date = .now) -> Date? {

--- a/Sources/SpeziScheduler/Task/Event.swift
+++ b/Sources/SpeziScheduler/Task/Event.swift
@@ -24,7 +24,7 @@ import Foundation
 ///
 /// ### Completing an Event
 /// - ``complete()``
-/// - ``complete(with:)``
+/// - ``complete(ignoreCompletionPolicy:with:)``
 @DebugDescription
 public struct Event {
     /// The outcome value.

--- a/Sources/SpeziScheduler/Task/Outcome.swift
+++ b/Sources/SpeziScheduler/Task/Outcome.swift
@@ -22,7 +22,7 @@ import SwiftData
 ///
 /// - Tip: Refer to the ``Property(coding:)`` macro on how to create new data types that can be stored alongside an outcome.
 ///
-/// You provide the additional outcome values upon completion of an event (see ``Event/complete(with:)``.
+/// You provide the additional outcome values upon completion of an event (see ``Event/complete(ignoreCompletionPolicy:with:)``.
 /// Below is a short code example that sets a custom `measurement` property to the weight measurement that was received
 /// from a connected weight scale.
 ///

--- a/Sources/SpeziSchedulerUI/EventScheduleList.swift
+++ b/Sources/SpeziSchedulerUI/EventScheduleList.swift
@@ -167,7 +167,7 @@ public struct EventScheduleList<Tile: View>: View {
     /// Create a new event schedule list.
     ///
     /// - parameter range: The (exclusive) range for which events should be displayed.
-    ///- Parameter makeEventTile: A closure that constructs the views for the individual `Event`s.
+    /// - parameter makeEventTile: A closure that constructs the views for the individual `Event`s.
     public init(for range: Range<Date>, @ViewBuilder content makeEventTile: @MainActor @escaping (Event) -> Tile) {
         self._events = .init(in: range)
         self.makeEventTile = makeEventTile

--- a/Sources/SpeziSchedulerUI/EventScheduleList.swift
+++ b/Sources/SpeziSchedulerUI/EventScheduleList.swift
@@ -158,7 +158,7 @@ public struct EventScheduleList<Tile: View>: View {
     /// Create a new event schedule list.
     /// - Parameters:
     ///   - date: The date for which events should be displayed. Defaults to today.
-    ///   - content: A closure that constructs the views for the individual ``Event``s.
+    ///   - makeEventTile: A closure that constructs the views for the individual `Event`s.
     public init(date: Date = .today, @ViewBuilder content makeEventTile: @MainActor @escaping (Event) -> Tile) {
         self.init(for: Calendar.current.rangeOfDay(for: date), content: makeEventTile)
     }
@@ -167,6 +167,7 @@ public struct EventScheduleList<Tile: View>: View {
     /// Create a new event schedule list.
     ///
     /// - parameter range: The (exclusive) range for which events should be displayed.
+    ///- Parameter makeEventTile: A closure that constructs the views for the individual `Event`s.
     public init(for range: Range<Date>, @ViewBuilder content makeEventTile: @MainActor @escaping (Event) -> Tile) {
         self._events = .init(in: range)
         self.makeEventTile = makeEventTile

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -10,6 +10,7 @@ import Spezi
 @_spi(TestingSupport)
 @testable import SpeziScheduler
 import XCTest
+import XCTRuntimeAssertions
 import XCTSpezi
 
 
@@ -255,5 +256,29 @@ final class SchedulerTests: XCTestCase {
                 lhs.task == rhs.task && lhs.occurrence == rhs.occurrence && lhs.isCompleted == rhs.isCompleted
             })
         }
+    }
+    
+    
+    @MainActor
+    func testSandboxDetection() throws {
+        /// function that will throw an error if initializing the `Scheduler` does not result in a `preconditionFailure`
+        let assertCreateModuleFails = {
+            // we need to write it like this, since simply having a trailing closure in the `XCTRuntimePrecondition` call
+            // (which then would create the Scheduler instance) would result in the compiler inferring that closure as being MainActor-constrained,
+            // the runtime isolation check for which would then fail, since XCTRuntimePrecondition evaluates the expression on a background thread.
+            nonisolated func imp() {
+                _ = Scheduler(persistence: .onDisk)
+            }
+            try XCTRuntimePrecondition(timeout: 2, "", imp)
+        }
+        #if os(macOS) || targetEnvironment(macCatalyst)
+        // we expect this to fail, since we're on macOS and the unit tests are not sandboxed
+        // if the assertCreateModuleFails function does NOT throw an error, the module creation resulted in a preconditionFailure.
+        XCTAssertNoThrow(try assertCreateModuleFails())
+        #else
+        // we expect this not to fail, since we're in a non-macOS (ie, sandboxed) environment
+        // if the assertCreateModuleFails function does throw an error, the module creation did NOT result in a preconditionFailure.
+        XCTAssertThrowsError(try assertCreateModuleFails())
+        #endif
     }
 }


### PR DESCRIPTION
# [macOS] prevent escaping the sandbox

## :recycle: Current situation & Problem
This PR fixes a bug introduced in #67, where the Scheduler module would end up storing its database into `~/Documents` when running on macOS outside of a sandbox.
The Scheduler module now checks that the current process is sandboxed, and will abort the program if it isn't.
This mainly was an issue in unit tests of other Spezi modules that themselves depended on the Scheduler (eg: SpeziStudy).

This PR also fixes some unrelated DocC issues.

## :gear: Release Notes
- the `Scheduler` now requires the current process be sandboxed; this change only affects macOS builds, since iOS/watchOS/etc are already always sandboxed


## :books: Documentation
the macOS sandboxing requirement is added to the docs

## :white_check_mark: Testing
there is a test for the new behaviour: we verify that creating an on-disk-persisted Scheduler works fine in sandboxed contexts, and fails in non-sandboxed contexts.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
