### PR TITLE
fix `deleteAllVersions`

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -436,7 +436,12 @@ extension Scheduler {
     /// - Parameter taskId: The task id for which you want to delete all versions. Refer to ``Task/id``.
     public func deleteAllVersions(ofTask taskId: String) throws {
         let context = try context
-        try context.delete(model: Task.self, where: #Predicate { $0.id == taskId })
+        let descriptor = FetchDescriptor(predicate: #Predicate<Task> {
+            $0.id == taskId
+        })
+        for task in try context.fetch(descriptor) {
+            context.delete(task)
+        }
         scheduleSave(for: context, forceSave: true, rescheduleNotifications: true)
     }
 }


### PR DESCRIPTION
# fix `deleteAllVersions`

## :recycle: Current situation & Problem
changes `Scheduler.deleteAllVersions(ofTask:)` to use `ModelContext.delete(_:)` instead of `ModelContext.delete(model:where:)`.

The reason for this change is that the old version resulted in incorrect notification scheduling and caused crashes in unit tests in other packages.
The underlying problem here seems to be that model deletions performed via `ModelContext.delete(model:where:)` only show up after the next `ModelContext.save()` call, whereas deletions performed via `ModelContext.delete(_:)` take effect immediately.

Example:
```swift
let descriptor = FetchDescriptor<Task>()
let tasksBefore = try context.fetch(descriptor) // fetch all tasks
precondition(!tasksBefore.isEmpty) // we have tasks
try context.delete(model: Task.self) // delete all tasks
let tasksAfter = try context.fetch(descriptor)
precondition(tasksBefore == tasksAfter) // we still have tasks (this will succeed)
```

the specific issue in the Scheduler is that the `scheduleSave(for context:forceSave:rescheduleNotifications:)` function (if `rescheduleNotifications` is true) typically ends up rescheduling the notifcations before the context save operation takes place (this is intended, i believe).
the notification rescheduling then needs to read the tasks from the context, but since `ModelContext.delete(model:where:)` was used to delete them, and the context hasn't yet been saved, it ends up fetching the old state of the tasks, including ones that have already been deleted.


## :gear: Release Notes
- fixed notification scheduling


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a (was only able to observe this via the SpeziStudy package, hence no regression test)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
