### PR TITLE
fix task deletion

### DIFF
--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -450,7 +450,7 @@ extension Scheduler {
     ///
     /// - Parameter task: The task and all versions of it to delete.
     public func deleteAllVersions(of task: Task) throws {
-        try deleteTasks(CollectionOfOne(task.firstVersion))
+        try deleteAllVersions(ofTask: task.id)
     }
     
     /// Delete all versions of the supplied task from the store.

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -420,7 +420,7 @@ extension Scheduler {
     ///     that the ``Task/schedule`` doesn't produce any more occurrences.
     ///
     /// - Parameter tasks: The list of task to delete.
-    public func deleteTasks(_ tasks: consuming some Collection<Task>) throws {
+    public func deleteTasks(_ tasks: some Collection<Task>) throws {
         guard !tasks.isEmpty else {
             return
         }
@@ -477,7 +477,7 @@ extension Scheduler {
                 return rhsIdx < lhsIdx
             }
             /// The oldest version of every ``Task`` that should be deleted.
-            oldestTaskVersionsToDelete = Array((consume tasks).reduce(into: Set<Task>()) { tasks, task in
+            oldestTaskVersionsToDelete = Array(tasks.reduce(into: Set<Task>()) { tasks, task in
                 guard !tasks.contains(task) else {
                     return
                 }

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -432,7 +432,7 @@ extension Scheduler {
         // The specific issue is the fact that our `Outcome.task` backlink is a non-optional `var task: Task`, which seems to trip SwiftData up.
         // One would think that this should be fine: every Outcome is associated with exactly one Task, and the `Task.outcomes` property defines
         // a cascading-delete rule, meaning that deleting a Task should also cause the deletion of all Outcomes associated with it.
-        // However, this does is not what actually happens, and instead SwiftData will crash when attempting to delete a Task for which at least
+        // However, this is not what actually happens, and instead SwiftData will crash when attempting to delete a Task for which at least
         // one Outcome exists, complaining that "Cannot remove Task from relationship task on Outcome because an appropriate default value is not configured".
         // Which, needless to say, should not constitute a fatal error, since the cascading-delete relationship between a Task and its Outcomes
         // stipulates that deleting the Task should also delete the Outcomes.

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -424,7 +424,43 @@ extension Scheduler {
         guard !tasks.isEmpty else {
             return
         }
-        let tasksToDelete: [Task]
+        // What's going on here?
+        //
+        // It seems to be the case that SwiftData's "cascading delete" doesn't work as advertised, in that attempting to delete a Task
+        // will fail (via a fatalError somewhere in SwiftData), if at least one Outcome exists for the Task.
+        // (See also FB18455306.)
+        // The specific issue is the fact that our `Outcome.task` backlink is a non-optional `var task: Task`, which seems to trip SwiftData up.
+        // One would think that this should be fine: every Outcome is associated with exactly one Task, and the `Task.outcomes` property defines
+        // a cascading-delete rule, meaning that deleting a Task should also cause the deletion of all Outcomes associated with it.
+        // However, this does is not what actually happens, and instead SwiftData will crash when attempting to delete a Task for which at least
+        // one Outcome exists, complaining that "Cannot remove Task from relationship task on Outcome because an appropriate default value is not configured".
+        // Which, needless to say, should not constitute a fatal error, since the cascading-delete relationship between a Task and its Outcomes
+        // stipulates that deleting the Task should also delete the Outcomes.
+        //
+        // In order to work around all of this, this function essentially re-implementes the cascading delete logic for deleting Tasks,
+        // ensuring that when deleting one or more Tasks, we delete the Tasks and their Outcomes in the correct order.
+        //
+        // The way we do this is that we have a preprocessing step transforming the `tasks` collection passed to the function:
+        // We determine, the effective "oldest" version of every Task we're asked to delete. I.e., if `tasks` contains
+        // multiple versions of the same logical task, we run a small subsumption check to determine which version would end up
+        // also deleting which other version (as part of the cascading delete that exists between a `Task` and its `nextVersion`).
+        //
+        // When performing the actual deletion, we proceed as follows:
+        // 1. We delete all Outcomes associated with each to-be-deleted Task version.
+        //     This needs to happen first, before we delete any Tasks, in order to ensure that there are no Outcomes for which
+        //     SwiftData might run into the missing appropriate default value issue.
+        //     When deleting the Outcomes, we iterate over each Task's version history, starting at the oldest version we're asked to delete
+        //     (the result of the subsumption test) and going forward all the way to the newest version.
+        // 2. We then (after deleting all Outcomes associated with Task versions we're asked to delete) need to perform
+        //     a save operation on the context. I'm not entirely sure why this is the case, but presumably in order for the cascading
+        //     delete logic in SwiftData not to see the Outcomes still existing in the storage.
+        //     (The bug there, i'd assume, being that SwiftData's cascading delete operation, when deleting a model referenced via an
+        //     inverse relationship, doesn't skip the deletion of that model if it's already been deleted as part of the current transaction.)
+        //     Needing the explicit `save()` here is unfortunate since it might have performance implications, but it's sadly unavoidable for now.
+        // 3. We then can delete the actual Tasks we're asked to delete. In this step, we can simply delete the oldest to-be-deleted
+        //     version of each task, without having to take care of the cascading delete ourselves.
+        //     (The reason probably being that `Task.previousVersion` and `Task.nextVersion` are both optional?)
+        let oldestTaskVersionsToDelete: [Task]
         let needsNotificationsUpdate: Bool
         do {
             /// Determines if a ``Task`` is subsumed by another ``Task``,
@@ -441,7 +477,7 @@ extension Scheduler {
                 return rhsIdx < lhsIdx
             }
             /// The oldest version of every ``Task`` that should be deleted.
-            let oldestTaskVersionsToDelete = (consume tasks).reduce(into: Set<Task>()) { tasks, task in
+            oldestTaskVersionsToDelete = Array((consume tasks).reduce(into: Set<Task>()) { tasks, task in
                 guard !tasks.contains(task) else {
                     return
                 }
@@ -458,27 +494,25 @@ extension Scheduler {
                 } else {
                     tasks.insert(task)
                 }
-            }
+            })
             needsNotificationsUpdate = oldestTaskVersionsToDelete.contains { task in
                 // If any of the tasks we're about to delete had notification scheduling, or if any of the tasks'
                 // previous versions (which, after the delete, will become the new current versions) had notification
                 // scheduling enabled, we need to perform an overall notification reschedule operation.
                 task.scheduleNotifications || task.previousVersion?.scheduleNotifications == true
             }
-            tasksToDelete = oldestTaskVersionsToDelete
-                .flatMap { sequence(first: $0, next: \.nextVersion).reversed() }
         }
         let context = try context
         // We first need to manually delete all Outcomes belonging to the tasks we're about to delete.
         // FB18455306 ([SwiftData] deleting model crashes bc of missing default value, despite cascading delete rule.)
-        for outcome in tasksToDelete.flatMap(\.outcomes) {
+        for outcome in oldestTaskVersionsToDelete.flatMap({ sequence(first: $0, next: \.nextVersion).flatMap(\.outcomes) }) {
             context.delete(outcome)
         }
         try context.save()
-        // Having deleted all referenced outcomes, and having saved the context, we can now delete the tasks.
-        // Note that the order in which we delete them matters (we need to delete newer versions of a task before older ones),
-        // but the code above has already taken care of this for us.
-        for task in tasksToDelete {
+        // Having deleted all referenced outcomes, and having saved the context, we can now delete the Tasks.
+        // Note that the cascading delete here works fine (presumably because the `Task.previousVersion` and `Task.nextVersion` properties are optional?),
+        // and we simply can delete the oldest version of each to-be-deleted Task.
+        for task in oldestTaskVersionsToDelete {
             context.delete(task)
         }
         scheduleSave(for: context, rescheduleNotifications: needsNotificationsUpdate)

--- a/Sources/SpeziScheduler/Task/Outcome.swift
+++ b/Sources/SpeziScheduler/Task/Outcome.swift
@@ -79,8 +79,8 @@ public final class Outcome {
     init(task: Task, occurrence: Occurrence) {
         self.id = UUID()
         self.completionDate = .now
-        self.task = task
         self.occurrenceStartDate = occurrence.start
+        self.task = task
     }
 }
 

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -166,6 +166,14 @@ public final class Task {
     public var firstVersion: Task {
         previousVersion?.firstVersion ?? self
     }
+    
+    var allVersions: UnfoldFirstSequence<Task> {
+        if let previousVersion {
+            return previousVersion.allVersions
+        } else {
+            return sequence(first: self, next: \.nextVersion)
+        }
+    }
 
     /// A reference to a previous version of this task.
     ///

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -167,12 +167,9 @@ public final class Task {
         previousVersion?.firstVersion ?? self
     }
     
+    /// A sequence containing, in order, all versions of this ``Task``.
     var allVersions: UnfoldFirstSequence<Task> {
-        if let previousVersion {
-            return previousVersion.allVersions
-        } else {
-            return sequence(first: self, next: \.nextVersion)
-        }
+        previousVersion?.allVersions ?? sequence(first: self, next: \.nextVersion)
     }
 
     /// A reference to a previous version of this task.

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -300,7 +300,7 @@ final class SchedulerTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
         try await waitABit()
         
-        try module.deleteAllVersions(ofTask: "task")
+        try module.deleteAllVersions(of: task2)
         try await waitABit()
         
         XCTAssert(try module.queryAllTasks().isEmpty)

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -265,11 +265,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test
     func deleteAllVersions() async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
             module
@@ -281,18 +276,15 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         let task = try addTask("task", schedule: .daily(hour: 0, minute: 0, startingAt: .now))
-        try await waitABit()
         
         do {
             let events = try module.queryEvents(forTaskWithId: "task", in: Calendar.current.rangeOfDay(for: .now))
             #expect(events.count == 1)
             try #require(events.first).complete()
         }
-        try await waitABit()
         
         // update the task (this will create a new version)
         let task2 = try addTask("task", schedule: .daily(hour: 23, minute: 59, second: 59, startingAt: .now))
-        try await waitABit()
         #expect(task2 == task.nextVersion)
         #expect(task2.previousVersion == task)
         
@@ -301,10 +293,8 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
             #expect(events.count == 1)
             try #require(events.first).complete()
         }
-        try await waitABit()
         
         try module.deleteAllVersions(of: task2)
-        try await waitABit()
         
         #expect(try module.queryAllTasks().isEmpty)
     }
@@ -312,11 +302,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test
     func deleteTaskSingleVersionNoOutcomes() async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let cal = Calendar.current
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
@@ -339,7 +324,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         let task = try addTask("task", startingAt: cal.startOfMonth(for: .now))
-        try await waitABit()
         
         try module.deleteTasks(task)
         
@@ -350,11 +334,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test
     func deleteTaskSingleVersionSomeOutcomes() async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let cal = Calendar.current
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
@@ -377,7 +356,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         let task = try addTask("task", startingAt: cal.startOfMonth(for: .now))
-        try await waitABit()
         
         for event in try module.queryEvents(for: cal.rangeOfMonth(for: .now)) {
             try event.complete()
@@ -395,11 +373,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test(arguments: DeleteAllTaskVersionsApproach.allCases)
     func deleteTaskMultipleVersionsNoOutcomes(deleteAllVersionsApproach: DeleteAllTaskVersionsApproach) async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let cal = Calendar.current
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
@@ -422,10 +395,7 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         let taskV1 = try addTask("task", startingAt: cal.startOfMonth(for: .now))
-        try await waitABit()
-        
         let taskV2 = try addTask("task", startingAt: cal.startOfNextMonth(for: .now))
-        try await waitABit()
         
         #expect(try Set(module.queryAllTasks()) == [taskV1, taskV2])
         #expect(try module.queryAllOutcomes().isEmpty)
@@ -445,11 +415,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test(arguments: DeleteAllTaskVersionsApproach.allCases)
     func deleteTaskMultipleVersionsSomeOutcomes(deleteAllVersionsApproach: DeleteAllTaskVersionsApproach) async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let cal = Calendar.current
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
@@ -472,18 +437,14 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         let taskV1 = try addTask("task", title: "V1", startingAt: cal.startOfMonth(for: .now))
-        try await waitABit()
         for event in try module.queryEvents(for: cal.rangeOfMonth(for: .now)) {
             try event.complete()
         }
-        try await waitABit()
         
         let taskV2 = try addTask("task", title: "V2", startingAt: cal.startOfNextMonth(for: .now))
-        try await waitABit()
         for event in try module.queryEvents(for: cal.rangeOfMonth(for: cal.startOfNextMonth(for: .now))) {
             try event.complete()
         }
-        try await waitABit()
         
         #expect(try Set(module.queryAllTasks()) == [taskV1, taskV2])
         #expect(try module.queryAllOutcomes().count == cal.numberOfDaysInMonth(for: .now) + cal.numberOfDaysInMonth(for: cal.startOfNextMonth(for: .now))) // swiftlint:disable:this line_length
@@ -504,11 +465,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
     
     @Test(arguments: DeleteAllTaskVersionsApproach.allCases)
     func deleteTask(deleteAllVersionsApproach: DeleteAllTaskVersionsApproach) async throws {
-        func waitABit() async throws {
-            // to give it some time to save everything
-            try await _Concurrency.Task.sleep(for: .seconds(0.25))
-        }
-        
         let cal = Calendar.current
         let module = Scheduler(persistence: .inMemory)
         withDependencyResolution {
@@ -531,7 +487,6 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
         }
         
         try addTask("task", startingAt: cal.startOfMonth(for: .now))
-        try await waitABit()
         
         for idx in 0..<12 {
             let task = try #require(module.queryAllTasks().max { $1.effectiveFrom > $0.effectiveFrom })


### PR DESCRIPTION
# fix task deletion

## :recycle: Current situation & Problem
follow-up to #74; attempts to fix another potential SwiftData crash when deleting a `Task`.

the issue here is that deleting a `Task` sometimes fails with SwiftData complaining about an "appropriate default value" not being configured. it doesn't tell is where exactly the default value is missing, but it's presumably the `Outcome`'s `task` property (which is a non-optional `Task`). ostensibly, this should work fine, given the fact that our model specifies cascarding deletion rules where necessary, but it seems like these sometimes aren't applied?

## :gear: Release Notes
- fixed a potential crash when deleting `Task`s


## :books: Documentation
the public docs are unchanged, but i've added an explainer to the delete function to outline what's going on, and why it's going on.


## :white_check_mark: Testing
we have several new tests, to test the deletion of various combinations of task versions and outcomes.
i also migrated some of the tests to Swift Testing


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
