### PR TITLE
expand the task appearance API; support explicit notification times

### DIFF
--- a/Sources/SpeziScheduler/Notifications/NotificationTime.swift
+++ b/Sources/SpeziScheduler/Notifications/NotificationTime.swift
@@ -6,9 +6,11 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
+
 
 /// Hour, minute and second date components to determine the scheduled time of a notification.
-public struct NotificationTime {
+public struct NotificationTime: Hashable, Codable, Sendable {
     /// The hour component.
     public let hour: Int
     /// The minute component.
@@ -26,12 +28,17 @@ public struct NotificationTime {
         self.hour = hour
         self.minute = minute
         self.second = second
-
         precondition((0..<24).contains(hour), "hour must be between 0 and 23")
         precondition((0..<60).contains(minute), "minute must be between 0 and 59")
         precondition((0..<60).contains(second), "second must be between 0 and 59")
     }
+    
+    
+    /// Returns a `Date` that represents this notification time in the specified day.
+    func date(in day: Date, using calendar: Calendar) -> Date {
+        guard let result = calendar.date(bySettingHour: hour, minute: minute, second: second, of: day) else {
+            preconditionFailure("Unable to adjust date.")
+        }
+        return result
+    }
 }
-
-
-extension NotificationTime: Sendable, Codable, Hashable {}

--- a/Sources/SpeziScheduler/Notifications/Schedule+Notifications.swift
+++ b/Sources/SpeziScheduler/Notifications/Schedule+Notifications.swift
@@ -17,15 +17,34 @@ extension Schedule {
         case components(month: Int?, day: Int?, hour: Int?, minute: Int, second: Int, weekday: Int?)
         case allDayNotification(weekday: Int?)
         
-        func dateComponents(calendar: Calendar, allDayNotificationTime: NotificationTime) -> DateComponents? {
+        func dateComponents(
+            calendar: Calendar,
+            preferredNotificationTime: NotificationTime?,
+            allDayNotificationTime: NotificationTime
+        ) -> DateComponents? {
             switch self {
             case .none:
                 return nil
             case let .components(month, day, hour, minute, second, weekday):
-                return DateComponents(calendar: calendar, month: month, day: day, hour: hour, minute: minute, second: second, weekday: weekday)
+                let time = preferredNotificationTime
+                return DateComponents(
+                    calendar: calendar,
+                    month: month,
+                    day: day,
+                    hour: time?.hour ?? hour,
+                    minute: time?.minute ?? minute,
+                    second: time?.second ?? second,
+                    weekday: weekday
+                )
             case let .allDayNotification(weekday):
                 let time = allDayNotificationTime
-                return DateComponents(calendar: calendar, hour: time.hour, minute: time.minute, second: time.second, weekday: weekday)
+                return DateComponents(
+                    calendar: calendar,
+                    hour: time.hour,
+                    minute: time.minute,
+                    second: time.second,
+                    weekday: weekday
+                )
             }
         }
     }
@@ -67,7 +86,11 @@ extension Schedule {
         }
     }
 
-    func canBeScheduledAsRepeatingCalendarTrigger(allDayNotificationTime: NotificationTime, now: Date = .now) -> Bool {
+    func canBeScheduledAsRepeatingCalendarTrigger(
+        preferredNotificationTime: NotificationTime?,
+        allDayNotificationTime: NotificationTime,
+        now: Date
+    ) -> Bool {
         guard notificationMatchingHint != .none, let recurrence else {
             return false // needs to be repetitive and have a interval hint
         }
@@ -79,6 +102,7 @@ extension Schedule {
         // otherwise, check if it still works (e.g., we have Monday, start date is Wednesday and schedule reoccurs every Friday).
         guard let components = notificationMatchingHint.dateComponents(
             calendar: recurrence.calendar,
+            preferredNotificationTime: preferredNotificationTime,
             allDayNotificationTime: allDayNotificationTime
         ) else {
             return false
@@ -94,21 +118,16 @@ extension Schedule {
             // we require at least two next occurrences to justify a **repeating** calendar-based trigger
             return false
         }
-
-        if duration.isAllDay {
+        
+        /// The time the next occurrence's notification should be sent out.
+        let nextOccurrenceEffectiveNotificationTime: Date = if duration.isAllDay {
             // we deliver notifications for all day occurrences at a different time
-            let time = allDayNotificationTime
-            guard let modifiedOccurrence = Calendar.current.date(
-                bySettingHour: time.hour,
-                minute: time.minute,
-                second: time.second,
-                of: nextOccurrence.start
-            ) else {
-                preconditionFailure("Failed to set notification time for date \(nextOccurrence.start)")
-            }
-            return nextDate == modifiedOccurrence
+            allDayNotificationTime.date(in: nextOccurrence.start, using: recurrence.calendar)
+        } else if let preferredNotificationTime {
+            preferredNotificationTime.date(in: nextOccurrence.start, using: recurrence.calendar)
         } else {
-            return nextDate == nextOccurrence.start
+            nextOccurrence.start
         }
+        return nextDate == nextOccurrenceEffectiveNotificationTime
     }
 }

--- a/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
+++ b/Sources/SpeziScheduler/Notifications/SchedulerNotifications.swift
@@ -420,6 +420,7 @@ extension SchedulerNotifications {
                     // ... if no events are left for this task we can immediately continue onto the next one
                     continue
                 }
+                let cal = event.task.schedule.recurrence?.calendar ?? cal
                 // ... we check whether this task's events are equidistant wrt to their start dates ...
                 let eventsDistances = upcomingEventsForCurrentTask.adjacentPairs().map { event0, event1 in
                     // Note that we're intentionally using DateComponents here, instead of simply calling timeIntervalSince;
@@ -431,11 +432,15 @@ extension SchedulerNotifications {
                     if let standard = standard as? any SchedulerNotificationsConstraint {
                         standard.notificationContent(for: event.task, content: content)
                     }
-                    let notificationDate = Schedule.notificationTime(
-                        for: event.occurrence.start,
-                        duration: event.occurrence.schedule.duration,
-                        allDayNotificationTime: allDayNotificationTime
-                    )
+                    let notificationDate = if let notificationTime = event.task.notificationTime {
+                        notificationTime.date(in: event.occurrence.start, using: cal)
+                    } else {
+                        Schedule.notificationTime(
+                            for: event.occurrence.start,
+                            duration: event.occurrence.schedule.duration,
+                            allDayNotificationTime: allDayNotificationTime
+                        )
+                    }
                     try await notifications.add(request: UNNotificationRequest(
                         identifier: Self.notificationId(for: event),
                         content: content,
@@ -446,9 +451,14 @@ extension SchedulerNotifications {
                 if implies(upcomingEventsForCurrentTask.count > 1, Set(eventsDistances).count == 1),
                    case let hint = event.task.schedule.notificationMatchingHint,
                    hint != .none,
-                   event.task.schedule.canBeScheduledAsRepeatingCalendarTrigger(allDayNotificationTime: allDayNotificationTime, now: now),
+                   event.task.schedule.canBeScheduledAsRepeatingCalendarTrigger(
+                    preferredNotificationTime: event.task.notificationTime,
+                    allDayNotificationTime: allDayNotificationTime,
+                    now: now
+                   ),
                    let triggerDateComponents = hint.dateComponents(
-                    calendar: event.task.schedule.recurrence?.calendar ?? cal,
+                    calendar: cal,
+                    preferredNotificationTime: event.task.notificationTime,
                     allDayNotificationTime: allDayNotificationTime
                    ) {
                     // ... if they are (and we actually have multiple events), we can schedule them via a single, repeating UNCalendarNotificationTrigger ...
@@ -460,7 +470,11 @@ extension SchedulerNotifications {
                         dateMatching: triggerDateComponents,
                         repeats: true
                     )
-                    let nextTriggerDate = event.occurrence.start
+                    let nextTriggerDate = if let notificationTime = event.task.notificationTime {
+                        notificationTime.date(in: event.occurrence.start, using: cal)
+                    } else {
+                        event.occurrence.start
+                    }
                     guard let nextNotificationTriggerDate = trigger.nextTriggerDate() else {
                         // this should probably be practically unreachable.
                         continue

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -276,12 +276,14 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
     ///   - completionPolicy: The policy to decide when an event can be completed by the user.
     ///   - scheduleNotifications: Automatically schedule notifications for upcoming events.
     ///   - notificationThread: The behavior how task notifications are grouped in the notification center.
+    ///   - notificationTime: The time when the Task's notifications should be sent out.
+    ///       Specifying `nil` will result in notifications being scheduled for the respective ``Occurrence``'s start date.
     ///   - tags: Custom tags associated with the task.
     ///   - effectiveFrom: The date from which this version of the task is effective. You typically do not want to modify this parameter.
-    ///     If you do specify a custom value, make sure to specify it relative to `now`.
+    ///       If you do specify a custom value, make sure to specify it relative to `now`.
     ///   - shadowedOutcomesHandling: How the scheduler should deal with shadowed outcomes when updating a task.
-    ///     You need to specify this parameter if you want to be able to proactively complete upcoming events.
-    ///     In this case, the call to `createOrUpdateTask` might
+    ///       You need to specify this parameter if you want to be able to proactively complete upcoming events.
+    ///       In this case, the call to `createOrUpdateTask` might
     ///   - contextClosure: The closure that allows to customize the ``Task/Context`` that is stored with the task.
     /// - Returns: Returns the latest version of the `task` and if the task was updated or created indicated by `didChange`.
     @discardableResult
@@ -294,6 +296,7 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
         completionPolicy: AllowedCompletionPolicy = .sameDay,
         scheduleNotifications: Bool = false,
         notificationThread: NotificationThread = .global,
+        notificationTime: NotificationTime? = nil,
         tags: [String]? = nil, // swiftlint:disable:this discouraged_optional_collection
         effectiveFrom: Date = .now,
         shadowedOutcomesHandling: TaskUpdateShadowedOutcomesHandling = .throwError,
@@ -318,6 +321,7 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
                 completionPolicy: completionPolicy,
                 scheduleNotifications: scheduleNotifications,
                 notificationThread: notificationThread,
+                notificationTime: notificationTime,
                 tags: tags,
                 effectiveFrom: effectiveFrom,
                 with: contextClosure
@@ -344,6 +348,7 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
                 completionPolicy: completionPolicy,
                 scheduleNotifications: scheduleNotifications,
                 notificationThread: notificationThread,
+                notificationTime: notificationTime,
                 tags: tags,
                 effectiveFrom: effectiveFrom,
                 with: contextClosure
@@ -363,6 +368,7 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
                 schedule: schedule,
                 completionPolicy: completionPolicy,
                 scheduleNotifications: scheduleNotifications,
+                notificationTime: notificationTime,
                 notificationThread: notificationThread,
                 tags: tags ?? [],
                 effectiveFrom: effectiveFrom,

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import SpeziFoundation
 import SwiftData
@@ -58,6 +60,7 @@ import SwiftData
 /// ### Notifications
 ///
 /// - ``scheduleNotifications``
+/// - ``notificationTime``
 /// - ``notificationThread``
 ///
 /// ### Modifying a task
@@ -131,6 +134,11 @@ public final class Task {
     /// events of this task. Refer to the documentation of `SchedulerNotifications` for all necessary steps and configuration in order to use this feature.
     public private(set) var scheduleNotifications: Bool
     
+    /// The time when the task's notifications should be sent out.
+    ///
+    /// In the case of a `nil` value, the notifications will match the respective ``Occurrence``'s start dates.
+    public private(set) var notificationTime: NotificationTime?
+    
     /// The behavior how task notifications are grouped in the notification center.
     public private(set) var notificationThread: NotificationThread
 
@@ -196,6 +204,7 @@ public final class Task {
         schedule: Schedule,
         completionPolicy: AllowedCompletionPolicy,
         scheduleNotifications: Bool,
+        notificationTime: NotificationTime?,
         notificationThread: NotificationThread,
         tags: [String],
         effectiveFrom: Date,
@@ -208,6 +217,7 @@ public final class Task {
         self.schedule = schedule
         self.completionPolicy = completionPolicy
         self.scheduleNotifications = scheduleNotifications
+        self.notificationTime = notificationTime
         self.notificationThread = notificationThread
         self.outcomes = []
         self.tags = tags
@@ -226,6 +236,7 @@ public final class Task {
         schedule: Schedule,
         completionPolicy: AllowedCompletionPolicy,
         scheduleNotifications: Bool,
+        notificationTime: NotificationTime?,
         notificationThread: NotificationThread,
         tags: [String],
         effectiveFrom: Date,
@@ -242,6 +253,7 @@ public final class Task {
             schedule: schedule,
             completionPolicy: completionPolicy,
             scheduleNotifications: scheduleNotifications,
+            notificationTime: notificationTime,
             notificationThread: notificationThread,
             tags: tags,
             effectiveFrom: effectiveFrom,
@@ -263,6 +275,7 @@ public final class Task {
     ///   - completionPolicy: The policy to decide when an event can be completed by the user.
     ///   - scheduleNotifications: Automatically schedule notifications for upcoming events.
     ///   - notificationThread: The behavior how task notifications are grouped in the notification center.
+    ///   - notificationTime: The time the tasks notifications should be sent out.
     ///   - tags: Custom tags associated with the task.
     ///   - effectiveFrom: The date this update is effective from.
     ///   - contextClosure: The updated context or `nil` if the context should not be updated.
@@ -288,6 +301,7 @@ public final class Task {
             completionPolicy: completionPolicy,
             scheduleNotifications: scheduleNotifications,
             notificationThread: notificationThread,
+            notificationTime: notificationTime,
             tags: tags,
             effectiveFrom: effectiveFrom,
             with: contextClosure
@@ -304,6 +318,7 @@ public final class Task {
         completionPolicy: AllowedCompletionPolicy?,
         scheduleNotifications: Bool?, // swiftlint:disable:this discouraged_optional_boolean
         notificationThread: NotificationThread?,
+        notificationTime: NotificationTime?,
         tags: [String]?, // swiftlint:disable:this discouraged_optional_collection
         effectiveFrom: Date,
         with contextClosure: ((inout Context) -> Void)?
@@ -324,6 +339,7 @@ public final class Task {
             || didChange(tags, for: \.tags)
             || didChange(scheduleNotifications, for: \.scheduleNotifications)
             || didChange(notificationThread, for: \.notificationThread)
+            || didChange(notificationTime, for: \.notificationTime)
             || didChange(context?.userInfo, for: \.userInfo)
     }
 
@@ -336,6 +352,7 @@ public final class Task {
         completionPolicy: AllowedCompletionPolicy?,
         scheduleNotifications: Bool?, // swiftlint:disable:this discouraged_optional_boolean
         notificationThread: NotificationThread?,
+        notificationTime: NotificationTime?,
         tags: [String]?, // swiftlint:disable:this discouraged_optional_collection
         effectiveFrom: Date,
         with contextClosure: ((inout Context) -> Void)?
@@ -348,6 +365,7 @@ public final class Task {
             completionPolicy: completionPolicy,
             scheduleNotifications: scheduleNotifications,
             notificationThread: notificationThread,
+            notificationTime: notificationTime,
             tags: tags,
             effectiveFrom: effectiveFrom,
             with: contextClosure
@@ -383,6 +401,7 @@ public final class Task {
             schedule: schedule ?? self.schedule,
             completionPolicy: completionPolicy ?? self.completionPolicy,
             scheduleNotifications: scheduleNotifications ?? self.scheduleNotifications,
+            notificationTime: notificationTime ?? self.notificationTime,
             notificationThread: notificationThread ?? self.notificationThread,
             tags: tags ?? self.tags,
             effectiveFrom: effectiveFrom,

--- a/Sources/SpeziSchedulerUI/Category/DisableCategoryDefaultAppearancesModifier.swift
+++ b/Sources/SpeziSchedulerUI/Category/DisableCategoryDefaultAppearancesModifier.swift
@@ -21,7 +21,7 @@ struct DisableCategoryDefaultAppearancesModifier: ViewModifier { // swiftlint:di
 
     func body(content: Content) -> some View {
         content
-            .environment(\.taskCategoryAppearances, taskCategoryAppearances.disableDefaultAppearances(disabled))
+            .environment(\.taskCategoryAppearances, taskCategoryAppearances.disablingDefaultAppearances(disabled))
     }
 }
 

--- a/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearances.swift
+++ b/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearances.swift
@@ -56,12 +56,7 @@ public struct TaskCategoryAppearances: Sendable {
     /// - Parameter category: The task category.
     /// - Returns: The appearance stored for the category.
     public subscript(_ category: Task.Category) -> Task.Category.Appearance? {
-        for provider in providers.reversed() {
-            if let appearance = provider(category) {
-                return appearance
-            }
-        }
-        return buildIntDefault(for: category)
+        providers.reversed().lazy.compactMap { $0(category) }.first ?? buildIntDefault(for: category)
     }
 }
 

--- a/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearances.swift
+++ b/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearances.swift
@@ -13,58 +13,62 @@ import SwiftUI
 
 
 /// Stores all configured category appearances for the view hierarchy.
-public struct TaskCategoryAppearances {
-    private let appearances: [Task.Category: Task.Category.Appearance]
+public struct TaskCategoryAppearances: Sendable {
+    public typealias AppearanceProvider = @Sendable (Task.Category) -> Task.Category.Appearance?
+    
+    private let providers: [AppearanceProvider]
     private let disableDefaultAppearances: Bool // for test purposes
-
+    
     init() {
-        self.init([:], disableDefaultAppearances: false)
+        self.init(providers: [], disableDefaultAppearances: false)
     }
-
-    init(_ appearances: [Task.Category: Task.Category.Appearance], disableDefaultAppearances: Bool) {
-        self.appearances = appearances
+    
+    init(providers: [AppearanceProvider], disableDefaultAppearances: Bool) {
+        self.providers = providers
         self.disableDefaultAppearances = disableDefaultAppearances
     }
-
+    
     private func buildIntDefault(for category: Task.Category) -> Task.Category.Appearance? {
         guard !disableDefaultAppearances else {
             return nil
         }
-
         return switch category {
         case .questionnaire:
-                .init(label: "Questionnaire", image: .system("heart.text.clipboard.fill"))
+            .init(label: "Questionnaire", image: .system("heart.text.clipboard.fill"))
         case .measurement:
-                .init(label: "Measurement", image: .system("heart.text.square.fill"))
+            .init(label: "Measurement", image: .system("heart.text.square.fill"))
         case .medication:
-                .init(label: "Medication", image: .system("pills.circle.fill"))
+            .init(label: "Medication", image: .system("pills.circle.fill"))
         default:
             nil
         }
     }
-
-    func inserting(_ appearance: Task.Category.Appearance, for category: Task.Category) -> Self {
-        var appearances = appearances
-        appearances[category] = appearance
-        return TaskCategoryAppearances(appearances, disableDefaultAppearances: disableDefaultAppearances)
+    
+    func appending(_ provider: @escaping AppearanceProvider) -> Self {
+        Self(providers: providers + [provider], disableDefaultAppearances: disableDefaultAppearances)
     }
 
-    func disableDefaultAppearances(_ disabled: Bool = true) -> Self {
-        TaskCategoryAppearances(appearances, disableDefaultAppearances: disabled)
+    func disablingDefaultAppearances(_ disabled: Bool = true) -> Self {
+        Self(providers: providers, disableDefaultAppearances: disabled)
     }
 
     /// Retrieve the appearance for a given category.
     /// - Parameter category: The task category.
     /// - Returns: The appearance stored for the category.
     public subscript(_ category: Task.Category) -> Task.Category.Appearance? {
-        appearances[category] ?? buildIntDefault(for: category)
+        for provider in providers.reversed() {
+            if let appearance = provider(category) {
+                return appearance
+            }
+        }
+        return buildIntDefault(for: category)
     }
 }
 
 
 extension Task.Category {
     /// Visual cues on how to render a task category to the user.
-    public struct Appearance {
+    public struct Appearance: Equatable, Sendable {
         /// The user-visible, localized label.
         public let label: LocalizedStringResource
         /// An optional image, that represents the category.
@@ -76,12 +80,6 @@ extension Task.Category {
         }
     }
 }
-
-
-extension Task.Category.Appearance: Sendable, Equatable {}
-
-
-extension TaskCategoryAppearances: Sendable, Equatable {}
 
 
 extension EnvironmentValues {

--- a/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearancesModifier.swift
+++ b/Sources/SpeziSchedulerUI/Category/TaskCategoryAppearancesModifier.swift
@@ -12,33 +12,40 @@ import SwiftUI
 
 
 private struct TaskCategoryAppearancesModifier: ViewModifier {
-    private let category: Task.Category
-    private let appearance: Task.Category.Appearance
+    let provider: TaskCategoryAppearances.AppearanceProvider
 
     @Environment(\.taskCategoryAppearances)
     private var appearances
 
-
-    init(category: Task.Category, appearance: Task.Category.Appearance) {
-        self.category = category
-        self.appearance = appearance
-    }
-
     func body(content: Content) -> some View {
         content
-            .environment(\.taskCategoryAppearances, appearances.inserting(appearance, for: category))
+            .environment(\.taskCategoryAppearances, appearances.appending(provider))
     }
 }
 
 
 extension View {
-    /// Define a new appearance for a task category.
+    /// Specify the appearance to be used for a task category.
     /// - Parameters:
     ///   - category: The task category to define a new appearance for.
     ///   - label: The user-visible, localized label that refers to the category.
     ///   - image: An optional image resource that refers to the category.
     /// - Returns: Returns the modified view, with the specified entry added to the ``SwiftUICore/EnvironmentValues/taskCategoryAppearances`` storage.
+    ///
+    /// - Note: Appearance definitions are processed in reverse order of how they are applied to a View; later appearances take precedence over earlier ones.
     public func taskCategoryAppearance(for category: Task.Category, label: LocalizedStringResource, image: ImageReference? = nil) -> some View {
-        modifier(TaskCategoryAppearancesModifier(category: category, appearance: .init(label: label, image: image)))
+        self.taskCategoryAppearance {
+            $0 == category ? .init(label: label, image: image) : nil
+        }
+    }
+    
+    /// Provide appearances for task categories.
+    ///
+    /// - parameter provider: A closure that maps a task category to an appearance definition.
+    ///
+    /// - Note: Appearance definitions are processed in reverse order of how they are applied to a View; later appearances take precedence over earlier ones.
+    ///     The first task category appearance provider that returns a nonnil value defines the task's appearance.
+    public func taskCategoryAppearance(_ provider: @escaping @Sendable (Task.Category) -> Task.Category.Appearance?) -> some View {
+        modifier(TaskCategoryAppearancesModifier(provider: provider))
     }
 }

--- a/Sources/SpeziSchedulerUI/TestingSupport/SchedulerSampleData.swift
+++ b/Sources/SpeziSchedulerUI/TestingSupport/SchedulerSampleData.swift
@@ -27,6 +27,7 @@ public struct SchedulerSampleData: PreviewModifier {
             schedule: .daily(hour: 17, minute: 0, startingAt: .today),
             completionPolicy: .sameDay,
             scheduleNotifications: false,
+            notificationTime: nil,
             notificationThread: .task,
             tags: [],
             effectiveFrom: .today // make sure test task always starts from the start of today

--- a/Tests/UITests/TestApp/ScheduleView.swift
+++ b/Tests/UITests/TestApp/ScheduleView.swift
@@ -84,7 +84,8 @@ struct ScheduleView: View {
                 EventDetailView(event)
             }
         }
-        .taskCategoryAppearance(for: Task.Category.labResults, label: "Enter Lab Results")
+        .taskCategoryAppearance(for: .labResults, label: "Enter Lab Results")
+        .taskCategoryAppearance(for: .timedWalkingTest, label: "Active Task", image: .system("figure.walk"))
     }
 
     @ToolbarContentBuilder private var toolbar: some ToolbarContent {
@@ -103,13 +104,11 @@ struct ScheduleView: View {
                 Text("Center").tag(HorizontalAlignment.center)
                 Text("Trailing").tag(HorizontalAlignment.trailing)
             }
-
             Picker("Date", selection: $dateSelection) {
                 Text("Today").tag(DateSelection.today)
                 Text("Tomorrow").tag(DateSelection.tomorrow)
                 Text("Date").tag(DateSelection.date)
             }
-
             Button("Hide Content", action: hide)
         }
     }

--- a/Tests/UITests/TestApp/TestAppScheduler.swift
+++ b/Tests/UITests/TestApp/TestAppScheduler.swift
@@ -26,6 +26,7 @@ enum TaskIdentifier {
     static let testMeasurement = "test-measurement"
     static let testMedication = "test-medication"
     static let enterLabResults = "enter-lab-results"
+    static let timedWalkingTest = "timed-walking-test"
 }
 
 
@@ -102,6 +103,16 @@ final class TestAppScheduler: Module {
                 scheduleNotifications: false,
                 shadowedOutcomesHandling: .delete
             )
+            
+            try scheduler.createOrUpdateTask(
+                id: TaskIdentifier.timedWalkingTest,
+                title: "Timed Walking Test",
+                instructions: "Walk for 6 minutes!",
+                category: .timedWalkingTest,
+                schedule: .daily(hour: 0, minute: 0, startingAt: .tomorrow),
+                scheduleNotifications: true,
+                notificationTime: NotificationTime(hour: 0, minute: 5)
+            )
         } catch {
             logger.error("Failed to scheduled TestApp tasks: \(error)")
             model.viewState = .error(AnyLocalizedError(
@@ -126,4 +137,5 @@ final class TestAppScheduler: Module {
 
 extension Task.Category {
     static let labResults = Self.custom("lab-results")
+    static let timedWalkingTest = Self.custom("timed-walking-test")
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -273,7 +273,7 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.collectionViews.staticTexts["Tomorrow"].waitForExistence(timeout: 1))
         XCTAssert(app.collectionViews.staticTexts["Timed Walking Test"].waitForExistence(timeout: 1))
         XCTAssert(app.collectionViews.staticTexts.matching(
-            NSPredicate(format: "label MATCHES 'Timed Walking Test, Active Task, In .*, \(uses12HourClock ? "0:00 AM" : "00:00")'")
+            NSPredicate(format: "label MATCHES 'Timed Walking Test, Active Task, In .*, \(uses12HourClock ? "12:00 AM" : "00:00")'")
         ).element.exists)
         
         // Part 2: verify the actual notification scheduling
@@ -294,7 +294,7 @@ class TestAppUITests: XCTestCase {
         )
         XCTAssert(app.staticTexts.matching(
             NSPredicate(format: "label MATCHES 'Date, calendar: .*hour: 0 minute: 5 second: 0.*'")
-        ).element.exists)
+        ).element.exists, "DateComponents don't match expected time values.")
     }
 }
 

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -12,6 +12,17 @@ import XCTSpeziNotifications
 
 
 class TestAppUITests: XCTestCase {
+    private var uses12HourClock: Bool {
+        switch Locale.current.hourCycle {
+        case .zeroToEleven, .oneToTwelve:
+            true
+        case .zeroToTwentyThree, .oneToTwentyFour:
+            false
+        @unknown default:
+            true // just assume it's running in the US
+        }
+    }
+    
     override func setUp() {
         continueAfterFailure = false
     }
@@ -29,13 +40,10 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["Today"].exists)
         XCTAssert(app.staticTexts["Social Support Questionnaire"].exists)
         XCTAssert(app.staticTexts["Questionnaire"].exists)
-        switch Locale.current.hourCycle {
-        case .oneToTwelve, .zeroToEleven:
+        if uses12HourClock {
             XCTAssert(app.staticTexts["4:00 PM"].exists)
-        case .oneToTwentyFour, .zeroToTwentyThree:
+        } else {
             XCTAssert(app.staticTexts["16:00"].exists)
-        @unknown default:
-            break
         }
 
         XCTAssert(app.buttons["More Information"].exists)
@@ -149,7 +157,7 @@ class TestAppUITests: XCTestCase {
         
         XCTAssert(app.buttons["Complete Enter Lab Results"].waitForExistence(timeout: 2))
         
-        app.goToTab("Notifications")
+        app.goToTab(.notifications)
 
         XCTAssert(app.staticTexts["Pending Notifications"].waitForExistence(timeout: 2.0))
 
@@ -173,10 +181,10 @@ class TestAppUITests: XCTestCase {
         )
         
         // Complete the task for today
-        app.goToTab("Schedule")
+        app.goToTab(.schedule)
         app.buttons["Complete Enter Lab Results"].tap()
         sleep(1)
-        app.goToTab("Notifications")
+        app.goToTab(.notifications)
         
         app.staticTexts["Enter Lab Results"].firstMatch.tap()
 
@@ -240,12 +248,65 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["did trigger, true"].waitForExistence(timeout: 2))
         XCTAssert(completeButton.waitForNonExistence(timeout: 2))
     }
+    
+    
+    @MainActor
+    func testExplicitNotificationTime() throws {
+        // What we test for here is that, when we define a Task with an explicit notificationTime,
+        // the start date of the task's occurrences and the time for which the notifications are scheduled,
+        // are both correct (and, importantly, different from each other!).
+        // In this case, we have a task that is scheduled for midnight, but doesn't want its notification until 00:05.
+        // (Note that the reason why these specific times are chosen is to minimise the likelihood the tests accidentally fail;
+        // if the test runs while the next occurrence is > 24 hours away the scheduler needs to fall back to a TimeInterval-based
+        // trigger, which we can't (easily) decompose into date components.)
+        let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        XCTAssert(app.wait(for: .runningForeground, timeout: 2.0))
+        
+        XCTAssert(app.collectionViews.staticTexts["Today"].waitForExistence(timeout: 1))
+        XCTAssertFalse(app.collectionViews.staticTexts["Timed Walking Test"].exists)
+        
+        // Part 1: verify the Schedule tab
+        app.navigationBars.buttons["More"].tap()
+        app.buttons["Date"].tap()
+        app.buttons["Tomorrow"].tap()
+        XCTAssert(app.collectionViews.staticTexts["Tomorrow"].waitForExistence(timeout: 1))
+        XCTAssert(app.collectionViews.staticTexts["Timed Walking Test"].waitForExistence(timeout: 1))
+        XCTAssert(app.collectionViews.staticTexts.matching(
+            NSPredicate(format: "label MATCHES 'Timed Walking Test, Active Task, In .*, \(uses12HourClock ? "0:00 AM" : "00:00")'")
+        ).element.exists)
+        
+        // Part 2: verify the actual notification scheduling
+        app.goToTab(.notifications)
+        XCTAssert(app.staticTexts["Pending Notifications"].waitForExistence(timeout: 1))
+        app.staticTexts["Timed Walking Test"].firstMatch.tap()
+        XCTAssert(app.navigationBars.staticTexts["Timed Walking Test"].waitForExistence(timeout: 1))
+        app.assertNotificationDetails(
+            identifier: "edu.stanford.spezi.scheduler.notification.task.timed-walking-test",
+            title: "Timed Walking Test",
+            body: "Walk for 6 minutes!",
+            category: "edu.stanford.spezi.scheduler.notification.category.timed-walking-test",
+            thread: "edu.stanford.spezi.scheduler.notification",
+            sound: true,
+            interruption: .timeSensitive,
+            type: "Calendar",
+            nextTrigger: nil
+        )
+        XCTAssert(app.staticTexts.matching(
+            NSPredicate(format: "label MATCHES 'Date, calendar: .*hour: 0 minute: 5 second: 0.*'")
+        ).element.exists)
+    }
 }
 
 
 extension XCUIApplication {
-    func goToTab(_ name: String, line: UInt = #line) {
-        let tab = self.tabBars.buttons[name]
+    enum Tab: String {
+        case schedule = "Schedule"
+        case notifications = "Notifications"
+    }
+    
+    func goToTab(_ tab: Tab, line: UInt = #line) {
+        let tab = self.tabBars.buttons[tab.rawValue]
         XCTAssert(tab.waitForExistence(timeout: 2.0), line: line)
         tab.tap()
         tab.tap()

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -98,7 +98,7 @@ class TestAppUITests: XCTestCase {
 
         app.confirmNotificationAuthorization()
         
-        XCTAssertGreaterThan(app.staticTexts.matching(identifier: "Medication").count, 5) // ensure events are scheduled
+        XCTAssertGreaterThan(app.staticTexts.matching(identifier: "Medication").count, 4) // ensure events are scheduled
 
         app.staticTexts["Weight Measurement"].tap()
 

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -29,7 +29,14 @@ class TestAppUITests: XCTestCase {
         XCTAssert(app.staticTexts["Today"].exists)
         XCTAssert(app.staticTexts["Social Support Questionnaire"].exists)
         XCTAssert(app.staticTexts["Questionnaire"].exists)
-        XCTAssert(app.staticTexts["4:00 PM"].exists)
+        switch Locale.current.hourCycle {
+        case .oneToTwelve, .zeroToEleven:
+            XCTAssert(app.staticTexts["4:00 PM"].exists)
+        case .oneToTwentyFour, .zeroToTwentyThree:
+            XCTAssert(app.staticTexts["16:00"].exists)
+        @unknown default:
+            break
+        }
 
         XCTAssert(app.buttons["More Information"].exists)
         app.buttons.matching(identifier: "More Information").element(boundBy: 1).tap()


### PR DESCRIPTION
# expand the task appearance API; support explicit notification times

## :recycle: Current situation & Problem
Reworks SpeziSchedulerUI's task appearance API to support not only hardcoded category → appearance mappings, but also allow custom closure-based appearance providers.
The intended use case here is apps that dynamically create categories which aren't necessarily known at compile time; in these cases, the closure-based API can be used to return proper appearances for these categories.

This is implemented in a way that the existing API should continue to work as-is; the `taskCategoryAppearance(for:label:image:)` modifier now is a wrapper around the new API.

Additionally, this PR fixes #78, adding the ability for Tasks to specify a custom notification time, which, if set, will be used to determine the time the task's notifications should be scheduled for (by adjusting the hour, minute, and second components of the task's scheduled time)

## :gear: Release Notes
- added the ability to specify closure-based task category appearance providers
- added optional `notificationTime` parameter to `createOrUpdateTask`


## :books: Documentation
the documentation has been updated to explain the new API and its behaviour.


## :white_check_mark: Testing
we have a new test for the notification times, and the appearance changes are covered by existing tests


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
