### PR TITLE
SpeziSchedulerUI adjustments

### DIFF
--- a/Sources/SpeziScheduler/Task/AllowedCompletionPolicy.swift
+++ b/Sources/SpeziScheduler/Task/AllowedCompletionPolicy.swift
@@ -25,6 +25,31 @@ public enum AllowedCompletionPolicy: Hashable, Sendable, Codable {
 
 
 extension AllowedCompletionPolicy {
+    /// Determine if an event is allowed to be completed at a specific date.
+    /// - Parameters:
+    ///   - event: The event.
+    ///   - date: The date for which the completion policy should be evaluated. Defaults to the `now` date.
+    ///   - calendar: The `Calendar` that should be used by the function.
+    /// - Returns: `true` if the event is allowed to be completed at `date`; `false` otherwise.
+    ///
+    /// - Note: If the date at which the event is allowed to be completed is still in the future,
+    ///     you can use the ``dateOnceCompletionIsAllowed(for:now:)`` and ``dateOnceCompletionBecomesDisallowed(for:now:)`` methods to retrieve the time
+    ///     when you need to update your UI.
+    public func isAllowedToComplete(event: Event, at date: Date = .now, using calendar: Calendar = .current) -> Bool {
+        switch self {
+        case .sameDay:
+            calendar.isDateInToday(date)
+        case .afterStart:
+            date >= event.occurrence.start
+        case .sameDayAfterStart:
+            calendar.isDateInToday(date) && date >= event.occurrence.start
+        case .duringEvent:
+            (event.occurrence.start..<event.occurrence.end).contains(date)
+        case .anytime:
+            true
+        }
+    }
+    
     /// Determine if an event is currently allowed to be completed.
     /// - Parameters:
     ///   - event: The event.
@@ -32,19 +57,9 @@ extension AllowedCompletionPolicy {
     /// - Returns: `true` if the event is currently allowed to be completed. `false` otherwise. If the date at which the event is allowed to be completed is still in the future,
     ///     you can use the ``dateOnceCompletionIsAllowed(for:now:)`` and ``dateOnceCompletionBecomesDisallowed(for:now:)`` methods to retrieve the time
     ///     when you need to update your UI.
+    @available(*, deprecated, renamed: "isAllowedToComplete(_:at:using:)")
     public func isAllowedToComplete(event: Event, now: Date = .now) -> Bool {
-        switch self {
-        case .sameDay:
-            Calendar.current.isDateInToday(now)
-        case .afterStart:
-            now >= event.occurrence.start
-        case .sameDayAfterStart:
-            Calendar.current.isDateInToday(now) && now >= event.occurrence.start
-        case .duringEvent:
-            (event.occurrence.start..<event.occurrence.end).contains(now)
-        case .anytime:
-            true
-        }
+        isAllowedToComplete(event: event, at: now)
     }
     
     /// Retrieve the date at which the result of `isAllowedToComplete` changes to allowed.

--- a/Sources/SpeziSchedulerUI/DefaultTileHeader.swift
+++ b/Sources/SpeziSchedulerUI/DefaultTileHeader.swift
@@ -14,11 +14,13 @@ import SwiftUI
 
 /// A default design for a tile that displays information about an event.
 public struct DefaultTileHeader: View {
-    private let alignment: HorizontalAlignment
-    private let event: Event
-
+    @Environment(\.calendar)
+    private var calendar
     @Environment(\.taskCategoryAppearances)
     private var taskCategoryAppearances
+    
+    private let alignment: HorizontalAlignment
+    private let event: Event
 
     public var body: some View {
         TileHeader(alignment: alignment) {
@@ -108,13 +110,15 @@ public struct DefaultTileHeader: View {
         case .allDay:
             nil
         case .tillEndOfDay:
-            if Calendar.current.isDateInToday(event.occurrence.start) {
+            if event.occurrence.start == calendar.startOfDay(for: .now) {
+                nil
+            } else if calendar.isDateInToday(event.occurrence.start) {
                 occurrenceStartTimeText()
             } else {
                 Text("\(dateOffsetText()), \(occurrenceStartTimeText())")
             }
         case .duration:
-            if Calendar.current.isDateInToday(event.occurrence.start) {
+            if calendar.isDateInToday(event.occurrence.start) {
                 occurrenceDurationText()
             } else {
                 Text("\(dateOffsetText()), \(occurrenceDurationText())")

--- a/Sources/SpeziSchedulerUI/InstructionsTile.swift
+++ b/Sources/SpeziSchedulerUI/InstructionsTile.swift
@@ -42,18 +42,28 @@ import SwiftUI
 /// })
 /// ```
 public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
+    /// The visibility of a component of an ``InstructionsTile``.
+    public enum ComponentVisibility: Hashable, Sendable {
+        /// The component should always be visible.
+        case showAlways
+        /// The component should be hidden if the event has already been completed.
+        case hideIfCompleted
+    }
+    
     private let alignment: HorizontalAlignment
     private let event: Event
     private let header: Header
     private let footer: Footer
-    private let moreInformation: Info
-
-    @State private var presentingMoreInformation: Bool = false
-
-
-    private var moreInfoButton: some View {
+    private let footerVisibility: ComponentVisibility
+    private let moreInfo: Info
+    private let moreInfoVisibility: ComponentVisibility
+    
+    @State private var isShowingMoreInfoSheet: Bool = false
+    
+    
+    private var moreButton: some View {
         Button {
-            presentingMoreInformation = true
+            isShowingMoreInfoSheet = true
         } label: {
             Label {
                 Text("More Information", bundle: .module)
@@ -62,10 +72,22 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
                     .accessibilityHidden(true)
             }
         }
-            .buttonStyle(.borderless)
-            .accessibilityLabel("More Information")
+        .buttonStyle(.borderless)
+        .accessibilityLabel("More Information")
     }
-
+    
+    private var moreButtonCompact: some View {
+        moreButton
+            .labelStyle(.iconOnly)
+            .font(.title3)
+    }
+    
+    private var moreButtonExtended: some View {
+        moreButton
+            .labelStyle(.titleAndIcon)
+            .font(.footnote)
+    }
+    
     private var tileAlignment: HorizontalAlignment {
         if event.isCompleted {
             .leading
@@ -73,32 +95,35 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
             alignment
         }
     }
-
+    
     public var body: some View {
         SimpleTile(alignment: tileAlignment) {
             if event.isCompleted {
-                CompletedTileHeader(alignment: tileAlignment) {
-                    Text(event.task.title)
+                HStack {
+                    CompletedTileHeader(alignment: tileAlignment) {
+                        Text(event.task.title)
+                    }
+                    switch moreInfoVisibility {
+                    case .showAlways:
+                        Spacer()
+                        moreButtonCompact
+                    case .hideIfCompleted:
+                        EmptyView() // if we end up in here, the event is already completed.
+                    }
                 }
             } else if Info.self != EmptyView.self {
                 let layout = alignment == .center
                 ? AnyLayout(VStackLayout(alignment: .leading, spacing: 8))
                 : AnyLayout(HStackLayout(alignment: .center))
-
                 layout {
                     header
-
                     if alignment == .center {
-                        moreInfoButton
-                            .labelStyle(.titleAndIcon)
-                            .font(.footnote)
+                        moreButtonExtended
                     } else {
                         if alignment == .leading {
                             Spacer()
                         }
-                        moreInfoButton
-                            .labelStyle(.iconOnly)
-                            .font(.title3)
+                        moreButtonCompact
                     }
                 }
             } else {
@@ -108,18 +133,52 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
             Text(event.task.instructions)
                 .font(.callout)
         } footer: {
-            if !event.isCompleted {
+            switch footerVisibility {
+            case .showAlways:
                 footer
+            case .hideIfCompleted:
+                if !event.isCompleted {
+                    footer
+                }
             }
         }
-            .sheet(isPresented: $presentingMoreInformation) {
-                moreInformation
-            }
-            .accessibilityAction(named: Text("More Information")) {
-                presentingMoreInformation = true
-            }
+        .sheet(isPresented: $isShowingMoreInfoSheet) {
+            moreInfo
+        }
+        .accessibilityAction(named: Text("More Information")) {
+            isShowingMoreInfoSheet = true
+        }
     }
     
+    
+    /// Create a new instructions with a header, a details view and a footer view.
+    /// - Parameters:
+    ///   - event: The event instance.
+    ///   - alignment: The horizontal alignment of the tile.
+    ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
+    ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
+    ///   - footer: A footer that is shown below the body of the tile. You may use the ``EventActionButton``.
+    public init(
+        _ event: Event,
+        alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
+        moreInfoVisibility: ComponentVisibility = .hideIfCompleted,
+        @ViewBuilder header: () -> Header,
+        @ViewBuilder footer: () -> Footer,
+        @ViewBuilder more: () -> Info
+    ) {
+        self.alignment = alignment
+        self.event = event
+        self.header = header()
+        self.footer = footer()
+        self.moreInfo = more()
+        self.footerVisibility = footerVisibility
+        self.moreInfoVisibility = moreInfoVisibility
+    }
+}
+
+
+extension InstructionsTile {
     /// Create a new instructions with an action button.
     ///
     /// This initializers uses the ``EventActionButton``.
@@ -130,9 +189,10 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
         action: @escaping () -> Void
     ) where Header == DefaultTileHeader, Footer == EventActionButton, Info == EmptyView {
-        self.init(event, alignment: alignment, action: action) {
+        self.init(event, alignment: alignment, footerVisibility: footerVisibility, action: action) {
             DefaultTileHeader(event, alignment: alignment)
         }
     }
@@ -148,10 +208,11 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
         action: @escaping () -> Void,
         @ViewBuilder header: () -> Header
     ) where Footer == EventActionButton, Info == EmptyView {
-        self.init(event, alignment: alignment, action: action, header: header) {
+        self.init(event, alignment: alignment, footerVisibility: footerVisibility, action: action, header: header) {
             EmptyView()
         }
     }
@@ -168,12 +229,16 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
+        moreInfoVisibility: ComponentVisibility = .hideIfCompleted,
         action: @escaping () -> Void,
         @ViewBuilder more: () -> Info
     ) where Header == DefaultTileHeader, Footer == EventActionButton {
         self.init(
             event,
             alignment: alignment,
+            footerVisibility: footerVisibility,
+            moreInfoVisibility: moreInfoVisibility,
             action: action,
             header: { DefaultTileHeader(event, alignment: alignment) },
             more: more
@@ -192,11 +257,21 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
+        moreInfoVisibility: ComponentVisibility = .hideIfCompleted,
         action: @escaping () -> Void,
         @ViewBuilder header: () -> Header,
         @ViewBuilder more: () -> Info
     ) where Footer == EventActionButton {
-        self.init(event, alignment: alignment, header: header, footer: { EventActionButton(event: event, action: action) }, more: more)
+        self.init(
+            event,
+            alignment: alignment,
+            footerVisibility: footerVisibility,
+            moreInfoVisibility: moreInfoVisibility,
+            header: header,
+            footer: { EventActionButton(event: event, action: action) },
+            more: more
+        )
     }
     
     /// Create a new instructions.
@@ -224,9 +299,16 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
         @ViewBuilder footer: () -> Footer
     ) where Header == DefaultTileHeader, Info == EmptyView {
-        self.init(event, alignment: alignment, header: { DefaultTileHeader(event, alignment: alignment) }, footer: footer)
+        self.init(
+            event,
+            alignment: alignment,
+            footerVisibility: footerVisibility,
+            header: { DefaultTileHeader(event, alignment: alignment) },
+            footer: footer
+        )
     }
 
     /// Create a new instructions tile with a details view.
@@ -240,9 +322,16 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        moreInfoVisibility: ComponentVisibility = .hideIfCompleted,
         @ViewBuilder more: () -> Info
     ) where Header == DefaultTileHeader, Footer == EmptyView {
-        self.init(event, alignment: alignment, header: { DefaultTileHeader(event, alignment: alignment) }, more: more)
+        self.init(
+            event,
+            alignment: alignment,
+            moreInfoVisibility: moreInfoVisibility,
+            header: { DefaultTileHeader(event, alignment: alignment) },
+            more: more
+        )
     }
     
     /// Create a new instructions with a header and no action view.
@@ -271,10 +360,11 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        footerVisibility: ComponentVisibility = .hideIfCompleted,
         @ViewBuilder header: () -> Header,
         @ViewBuilder footer: () -> Footer
     ) where Info == EmptyView {
-        self.init(event, alignment: alignment, header: header, footer: footer) {
+        self.init(event, alignment: alignment, footerVisibility: footerVisibility, header: header, footer: footer) {
             EmptyView()
         }
     }
@@ -289,31 +379,18 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     public init(
         _ event: Event,
         alignment: HorizontalAlignment = .leading,
+        moreInfoVisibility: ComponentVisibility = .hideIfCompleted,
         @ViewBuilder header: () -> Header,
         @ViewBuilder more: () -> Info
     ) where Footer == EmptyView {
-        self.init(event, alignment: alignment, header: header, footer: { EmptyView() }, more: more)
-    }
-
-    /// Create a new instructions with a header, a details view and a footer view.
-    /// - Parameters:
-    ///   - event: The event instance.
-    ///   - alignment: The horizontal alignment of the tile.
-    ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
-    ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
-    ///   - footer: A footer that is shown below the body of the tile. You may use the ``EventActionButton``.
-    public init(
-        _ event: Event,
-        alignment: HorizontalAlignment = .leading,
-        @ViewBuilder header: () -> Header,
-        @ViewBuilder footer: () -> Footer,
-        @ViewBuilder more: () -> Info
-    ) {
-        self.alignment = alignment
-        self.event = event
-        self.header = header()
-        self.footer = footer()
-        self.moreInformation = more()
+        self.init(
+            event,
+            alignment: alignment,
+            moreInfoVisibility: moreInfoVisibility,
+            header: header,
+            footer: { EmptyView() },
+            more: more
+        )
     }
 }
 

--- a/Sources/SpeziSchedulerUI/InstructionsTile.swift
+++ b/Sources/SpeziSchedulerUI/InstructionsTile.swift
@@ -155,6 +155,9 @@ public struct InstructionsTile<Header: View, Info: View, Footer: View>: View {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
+    ///   - moreInfoVisibility: Controls when the tile's "more info" button will be displayed.
     ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
     ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
     ///   - footer: A footer that is shown below the body of the tile. You may use the ``EventActionButton``.
@@ -185,6 +188,8 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
     ///   - action: The closure that is executed if the action button is pressed.
     public init(
         _ event: Event,
@@ -203,6 +208,8 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
     ///   - action: The closure that is executed if the action button is pressed.
     ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
     public init(
@@ -223,6 +230,9 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
+    ///   - moreInfoVisibility: Controls when the tile's "more info" button will be displayed.
     ///   - action: The closure that is executed if the action button is pressed.
     ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
     @_disfavoredOverload
@@ -251,6 +261,9 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
+    ///   - moreInfoVisibility: Controls when the tile's "more info" button will be displayed.
     ///   - action: The closure that is executed if the action button is pressed.
     ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
     ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
@@ -295,6 +308,8 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
     ///   - footer: A footer that is shown below the body of the tile. You may use the ``EventActionButton``.
     public init(
         _ event: Event,
@@ -317,6 +332,7 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - moreInfoVisibility: Controls when the tile's "more info" button will be displayed.
     ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.
     @_disfavoredOverload
     public init(
@@ -354,6 +370,8 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - footerVisibility: Controls when the tile's footer view will be displayed.
+    ///       The footer view is used e.g. to display the ``EventActionButton``; controlling this behaviour allows you to offer an already-completed task be performed again.
     ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
     ///   - footer: A footer that is shown below the body of the tile. You may use the ``EventActionButton``.
     @_disfavoredOverload
@@ -373,6 +391,7 @@ extension InstructionsTile {
     /// - Parameters:
     ///   - event: The event instance.
     ///   - alignment: The horizontal alignment of the tile.
+    ///   - moreInfoVisibility: Controls when the tile's "more info" button will be displayed.
     ///   - header: A custom header that is shown on the top of the tile. You can use the [`TileHeader`](https://swiftpackageindex.com/stanfordspezi/speziviews/documentation/speziviews/tileheader)
     ///     view as a basis for your implementation.
     ///   - more: An optional view that is presented as a sheet if the user presses the "more information" button. The view can be used to provide additional explanation or instructions for a task.


### PR DESCRIPTION
# SpeziSchedulerUI adjustments

## :recycle: Current situation & Problem
currently, it is impossible for an app to allow a task be performed (not necessarily completed) multiple times using the UI elements provided by SpeziSchedulerUI.
this PR attempts to fix this, by introducing the abillity to control when an `InstructionTile` displays its footer and/or "more info" views.
by default, we retain the current behaviour of hiding the footer and the "more info" button if the event is already completed, but this can now be overwritten to have either/both of them be displayed always ie also if the event is already completed.

NOTE: this does not make any "complete an event multiple times"-related changes to the scheduler/event/etc logic.
it is already possible to complete an event multiple times, in which case the existing `Outcome` will be overwritten.
additionally, the `EventActionButton` already doesn't take an Event's completion state into account w.r.t. its own enabled/disable state.
the changes from this PR (allowing control over when the `InstructionsTile` displays its "perform the event" button) is the missing piece to enable easy event repetitions using SpeziSchedulerUI.


## :gear: Release Notes
- added optional `footerVisibility` and `moreInfoVisibility` parameters to the `InstructionTile`'s initializers


## :books: Documentation
the new type is documented, and existing documentation has been updated


## :white_check_mark: Testing
*todo*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
