### PR TITLE
fixes; task version history mutation APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: CI
-    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@v2
+  setup:
+    name: Setup
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-setup.yml@v2
+
+  build_and_test:
+    name: Build & Test
+    needs: setup
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-test.yml@v2
     with:
+      package_name: ${{ needs.setup.outputs.package_name }}
+      scheme: ${{ needs.setup.outputs.scheme }}
+      platform_matrix: ${{ needs.setup.outputs.platform_matrix }}
+      ui_platform_matrix: ${{ needs.setup.outputs.ui_platform_matrix }}
       linux_run_tests: false
     secrets: inherit
+
+  static_analysis:
+    name: Static Analysis
+    needs: setup
+    # diagnose_breaking_changes is disabled due to a Swift PM bug: `swift package diagnose-api-breaking-changes`
+    # fails with a "redefinition of module 'SpeziFoundationObjC'" error when the package has a .macro() target
+    # on macOS. The macro causes Swift PM to create a SpeziFoundationObjC-tool.build directory in the current
+    # build, which conflicts with SpeziFoundationObjC.build in the cached apidiff baseline checkout.
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-static-analysis.yml@v2
+    with:
+      library_products: ${{ needs.setup.outputs.library_products }}
+      platform_name: ${{ needs.setup.outputs.platform_name }}
+      platform_version: ${{ needs.setup.outputs.platform_version }}
+      diagnose_breaking_changes: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 
 # Spezi Scheduler
 
-[![Build and Test](https://github.com/StanfordSpezi/SpeziScheduler/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordSpezi/SpeziScheduler/actions/workflows/build-and-test.yml)
+[![Build and Test](https://github.com/StanfordSpezi/SpeziScheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/StanfordSpezi/SpeziScheduler/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/StanfordSpezi/SpeziScheduler/branch/main/graph/badge.svg?token=0SRI67ItFw)](https://codecov.io/gh/StanfordSpezi/SpeziScheduler)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7706954.svg)](https://doi.org/10.5281/zenodo.7706954)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpeziScheduler%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/SpeziScheduler)

--- a/Sources/SpeziScheduler/Notifications/BackgroundMode.swift
+++ b/Sources/SpeziScheduler/Notifications/BackgroundMode.swift
@@ -8,7 +8,7 @@
 
 #if canImport(Darwin)
 @usableFromInline
-struct BackgroundMode {
+struct BackgroundMode: RawRepresentable, Codable, Hashable, Sendable {
     @usableFromInline static let processing = BackgroundMode(rawValue: "processing")
     @usableFromInline static let fetch = BackgroundMode(rawValue: "fetch")
 
@@ -19,7 +19,4 @@ struct BackgroundMode {
         self.rawValue = rawValue
     }
 }
-
-
-extension BackgroundMode: RawRepresentable, Codable, Hashable, Sendable {}
 #endif

--- a/Sources/SpeziScheduler/Notifications/PermittedBackgroundTaskIdentifier.swift
+++ b/Sources/SpeziScheduler/Notifications/PermittedBackgroundTaskIdentifier.swift
@@ -8,7 +8,7 @@
 
 #if canImport(Darwin)
 @usableFromInline
-struct PermittedBackgroundTaskIdentifier {
+struct PermittedBackgroundTaskIdentifier: RawRepresentable, Hashable, Sendable, Codable {
     @usableFromInline static let speziSchedulerNotificationsScheduling = PermittedBackgroundTaskIdentifier(
         rawValue: "edu.stanford.spezi.scheduler.notifications-scheduling"
     )
@@ -20,7 +20,4 @@ struct PermittedBackgroundTaskIdentifier {
         self.rawValue = rawValue
     }
 }
-
-
-extension PermittedBackgroundTaskIdentifier: RawRepresentable, Hashable, Sendable, Codable {}
 #endif

--- a/Sources/SpeziScheduler/Schedule/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule/Schedule.swift
@@ -53,7 +53,7 @@ import Foundation
 /// - ``occurrences(inDay:)``
 /// - ``occurrences(in:)-3a9p3``
 /// - ``occurrence(forStartDate:)``
-public struct Schedule {
+public struct Schedule: Sendable {
     /// The start date (inclusive).
     private var startDate: Date
     /// The duration of a single occurrence.
@@ -61,7 +61,7 @@ public struct Schedule {
     /// We need a separate storage container as SwiftData cannot store values of type `Swift.Duration`.
     private var scheduleDuration: Duration.SwiftDataDuration
 
-
+    /// Backing storage for ``recurrence``
     private var recurrenceRule: Data?
 
     /// A simpler representation of the recurrence rule used for notification scheduling.
@@ -205,7 +205,37 @@ public struct Schedule {
 }
 
 
-extension Schedule: Hashable, Sendable, Codable {/*
+extension Schedule: Equatable, Hashable {
+    public static func == (lhs: Schedule, rhs: Schedule) -> Bool {
+        // NOTE: we intentionally manually compare all of the relevant properties here,
+        // since the recurrence rule is stored as `Data`, which does not necessarily compare equal for
+        // recurrence rules that do compare equal.
+        lhs.startDate == rhs.startDate
+            && lhs.scheduleDuration == rhs.scheduleDuration
+            && lhs.notificationMatchingHint == rhs.notificationMatchingHint
+            && lhs.duration == rhs.duration
+            && lhs.recurrence == rhs.recurrence
+            && lhs.start == rhs.start
+            && lhs.repeatsIndefinitely == rhs.repeatsIndefinitely
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(startDate)
+        hasher.combine(scheduleDuration)
+        hasher.combine(notificationMatchingHint)
+        hasher.combine(duration)
+        if #available(iOS 18.2, macOS 15.2, visionOS 2.2, watchOS 11.2, *) {
+            hasher.combine(recurrence)
+        } else {
+            hasher.combine(recurrenceRule)
+        }
+        hasher.combine(start)
+        hasher.combine(repeatsIndefinitely)
+    }
+}
+
+
+extension Schedule: Codable {/*
     private enum CodingKeys: String, CodingKey {
         case startDate
         case scheduleDuration

--- a/Sources/SpeziScheduler/Schedule/Schedule.swift
+++ b/Sources/SpeziScheduler/Schedule/Schedule.swift
@@ -224,10 +224,13 @@ extension Schedule: Equatable, Hashable {
         hasher.combine(scheduleDuration)
         hasher.combine(notificationMatchingHint)
         hasher.combine(duration)
+        // Only fold the recurrence into the hash on platforms where `Calendar.RecurrenceRule` is `Hashable`.
+        // Falling back to the raw `recurrenceRule` on older systems would be unsound: `==` compares the decoded
+        // `recurrence`, and two schedules that are equal there can still carry different `Data` blobs (see the note
+        // in `==`). Mixing that `Data` in would let equal values hash differently, violating the `a == b` implies
+        // equal-hashes requirement. Omitting it simply yields a coarser hash, which is always permitted.
         if #available(iOS 18.2, macOS 15.2, visionOS 2.2, watchOS 11.2, *) {
             hasher.combine(recurrence)
-        } else {
-            hasher.combine(recurrenceRule)
         }
         hasher.combine(start)
         hasher.combine(repeatsIndefinitely)

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -164,7 +164,9 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
         }
     }
     
-    var context: ModelContext {
+    /// The SwiftData `ModelContext` used by the Scheduler.
+    @_spi(APISupport)
+    public var context: ModelContext {
         get throws {
             try container.mainContext
         }
@@ -264,7 +266,6 @@ public final class Scheduler: Module, EnvironmentAccessible, DefaultInitializabl
         // It also makes it easier to understand the SwiftData-related infrastructure around Spezi Scheduler.
         // One could think that Apple could have provided a lot of this information in their documentation.
         notifications.registerProcessingTask(using: self)
-        
         assert(
             ((try? self.queryAllTasks()) ?? []).allSatisfy { $0.allVersions.adjacentPairs().allSatisfy { $0.effectiveFrom < $1.effectiveFrom } },
             "Scheduler Database contains Tasks with non-increasing effectiveFrom values!"

--- a/Sources/SpeziScheduler/Task/Outcome.swift
+++ b/Sources/SpeziScheduler/Task/Outcome.swift
@@ -83,6 +83,12 @@ public final class Outcome {
         self.occurrenceStartDate = occurrence.start
         self.task = task
     }
+    
+    /// Unsafely (i.e., potentially breaking invariants) updates the Outcome's associated ``Task``.
+    @_spi(APISupport)
+    public func unsafelyReassignTask(to newTask: Task) {
+        self.task = newTask
+    }
 }
 
 

--- a/Sources/SpeziScheduler/Task/Outcome.swift
+++ b/Sources/SpeziScheduler/Task/Outcome.swift
@@ -99,10 +99,10 @@ extension Outcome {
     @_documentation(visibility: internal)
     public subscript<Source: OutcomeStorageKey>(_ source: Source.Type) -> Source.Value? {
         get {
-            userInfo.get(source, cache: &userInfoCache)
+            try? userInfo.get(source, cache: &userInfoCache)
         }
         set {
-            userInfo.set(source, value: newValue, cache: &userInfoCache)
+            try? userInfo.set(source, value: newValue, cache: &userInfoCache)
         }
     }
 
@@ -114,10 +114,10 @@ extension Outcome {
     @_documentation(visibility: internal)
     public subscript<Source: OutcomeStorageKey>(_ source: Source.Type, default defaultValue: @autoclosure () -> Source.Value) -> Source.Value {
         get {
-            userInfo.get(source, cache: &userInfoCache) ?? defaultValue()
+            (try? userInfo.get(source, cache: &userInfoCache)) ?? defaultValue()
         }
         set {
-            userInfo.set(source, value: newValue, cache: &userInfoCache)
+            try? userInfo.set(source, value: newValue, cache: &userInfoCache)
         }
     }
 }

--- a/Sources/SpeziScheduler/Task/Task+Category.swift
+++ b/Sources/SpeziScheduler/Task/Task+Category.swift
@@ -27,7 +27,7 @@ extension Task {
     ///
     /// ### Creating a new Category
     /// - ``custom(_:)``
-    public struct Category {
+    public struct Category: Hashable, Sendable, RawRepresentable, Codable {
         /// The category name.
         @_spi(APISupport)
         public let rawValue: String
@@ -39,9 +39,6 @@ extension Task {
         }
     }
 }
-
-
-extension Task.Category: Hashable, Sendable, RawRepresentable, Codable {}
 
 
 extension Task.Category: CustomStringConvertible {

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -225,7 +225,8 @@ public final class Task { // swiftlint:disable:this type_body_length
     public private(set) var nextVersion: Task?
 
     /// Additional userInfo stored alongside the task.
-    private(set) var userInfo: UserInfoStorage<TaskAnchor>
+    @_spi(APISupport)
+    public private(set) var userInfo: UserInfoStorage<TaskAnchor>
     @Transient private var userInfoCache = UserInfoStorage<TaskAnchor>.RepositoryCache()
 
     private init(
@@ -355,24 +356,57 @@ public final class Task { // swiftlint:disable:this type_body_length
         effectiveFrom: Date,
         with contextClosure: ((inout Context) -> Void)?
     ) -> Bool {
+        !keyPathsNecessitatingNewTaskVersion(
+            title: title,
+            instructions: instructions,
+            category: category,
+            schedule: schedule,
+            completionPolicy: completionPolicy,
+            scheduleNotifications: scheduleNotifications,
+            notificationThread: notificationThread,
+            notificationTime: notificationTime,
+            tags: tags,
+            effectiveFrom: effectiveFrom,
+            with: contextClosure
+        ).isEmpty
+    }
+    
+    /// Determines which properties of the task would necessitate a new version be created.
+    @_spi(APISupport)
+    public func keyPathsNecessitatingNewTaskVersion( // swiftlint:disable:this function_parameter_count
+        title: String.LocalizationValue?,
+        instructions: String.LocalizationValue?,
+        category: Category?,
+        schedule: Schedule?,
+        completionPolicy: AllowedCompletionPolicy?,
+        scheduleNotifications: Bool?, // swiftlint:disable:this discouraged_optional_boolean
+        notificationThread: NotificationThread?,
+        notificationTime: NotificationTime?,
+        tags: [String]?, // swiftlint:disable:this discouraged_optional_collection
+        effectiveFrom: Date,
+        with contextClosure: ((inout Context) -> Void)?
+    ) -> Set<PartialKeyPath<Task>> {
         let context: Context? = contextClosure.map { apply in
             var context = Context()
             apply(&context)
             return context
         }
-        func didChange<V: Equatable>(_ value: V?, for keyPath: KeyPath<Task, V>) -> Bool {
-            value != nil && value != self[keyPath: keyPath]
+        func imp<V: Equatable>(_ value: V?, for keyPath: KeyPath<Task, V>) -> KeyPath<Task, V>? {
+            let didChange = value != nil && value != self[keyPath: keyPath]
+            return didChange ? keyPath : nil
         }
-        return didChange(title, for: \.title)
-            || didChange(instructions, for: \.instructions)
-            || didChange(category, for: \.category)
-            || didChange(schedule, for: \.schedule)
-            || didChange(completionPolicy, for: \.completionPolicy)
-            || didChange(tags, for: \.tags)
-            || didChange(scheduleNotifications, for: \.scheduleNotifications)
-            || didChange(notificationThread, for: \.notificationThread)
-            || didChange(notificationTime, for: \.notificationTime)
-            || didChange(context?.userInfo, for: \.userInfo)
+        return Set {
+            imp(title, for: \.title)
+            imp(instructions, for: \.instructions)
+            imp(category, for: \.category)
+            imp(schedule, for: \.schedule)
+            imp(completionPolicy, for: \.completionPolicy)
+            imp(tags, for: \.tags)
+            imp(scheduleNotifications, for: \.scheduleNotifications)
+            imp(notificationThread, for: \.notificationThread)
+            imp(notificationTime, for: \.notificationTime)
+            imp(context?.userInfo, for: \.userInfo)
+        }
     }
 
     func createUpdatedVersion( // swiftlint:disable:this function_parameter_count
@@ -516,6 +550,18 @@ extension Task {
                 userInfo.set(source, value: newValue, cache: &box.userInfoCache)
             }
         }
+        
+        /// Access members of the tasks context.
+        ///
+        /// This subscript allows to dynamically access members of the ``Context`` of the task.
+        ///
+        /// - Parameter keyPath: The key path to a property of the `Context`.
+        /// - Returns: The value for that property `Context`.
+        @_documentation(visibility: internal)
+        public subscript<Value>(dynamicMember keyPath: KeyPath<Self, Value>) -> Value {
+            let context = Context(userInfo: userInfo, userInfoCache: userInfoCache)
+            return context[keyPath: keyPath]
+        }
     }
 }
 
@@ -524,6 +570,27 @@ extension Task {
     func _updateTitle(_ title: String.LocalizationValue, instructions: String.LocalizationValue) { // swiftlint:disable:this identifier_name
         self.title = title
         self.instructions = instructions
+    }
+    
+    /// Unsafely updates the task's ``userInfo``.
+    ///
+    /// - Important: Only call this function if you know what you are doing!
+    @_spi(APISupport)
+    public func unsafelyUpdateContext(
+        _ update: (_ context: inout Task.Context) throws -> Void
+    ) rethrows {
+        var context = Context(userInfo: userInfo, userInfoCache: userInfoCache)
+        try update(&context)
+        self.userInfo = context.userInfo
+        self.userInfoCache = context.userInfoCache
+    }
+    
+    /// Unsafely updates the task's ``nextVersion``.
+    ///
+    /// - Important: Only call this function if you know what you are doing!
+    @_spi(APISupport)
+    public func unsafelyUpdateNextVersion(to newNextVersion: Task?) {
+        self.nextVersion = newNextVersion
     }
 }
 
@@ -591,3 +658,14 @@ extension Task: CustomStringConvertible {
     }
 }
 #endif
+
+
+extension SetBuilder {
+    static func buildExpression(_ expression: Element?) -> Set<Element> {
+        if let expression {
+            Set(CollectionOfOne(expression))
+        } else {
+            Set()
+        }
+    }
+}

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -578,18 +578,6 @@ extension Task {
                 try? userInfo.set(source, value: newValue, cache: &box.userInfoCache)
             }
         }
-        
-        /// Access members of the tasks context.
-        ///
-        /// This subscript allows to dynamically access members of the ``Context`` of the task.
-        ///
-        /// - Parameter keyPath: The key path to a property of the `Context`.
-        /// - Returns: The value for that property `Context`.
-        @_documentation(visibility: internal)
-        public subscript<Value>(dynamicMember keyPath: KeyPath<Self, Value>) -> Value {
-            let context = Context(userInfo: userInfo, userInfoCache: userInfoCache)
-            return context[keyPath: keyPath]
-        }
     }
 }
 

--- a/Sources/SpeziScheduler/Task/Task.swift
+++ b/Sources/SpeziScheduler/Task/Task.swift
@@ -495,6 +495,34 @@ public final class Task { // swiftlint:disable:this type_body_length
         let context = Context(userInfo: userInfo, userInfoCache: userInfoCache)
         return context[keyPath: keyPath]
     }
+    
+    /// Retrieve or set the value for a given storage key.
+    /// - Parameter source: The storage key.
+    /// - Returns: The value or `nil` if there isn't currently a value stored in the outcome.
+    @_documentation(visibility: internal)
+    public subscript<Source: TaskStorageKey>(_ source: Source.Type) -> Source.Value? {
+        get {
+            try? userInfo.get(source, cache: &userInfoCache)
+        }
+        set {
+            try? userInfo.set(source, value: newValue, cache: &userInfoCache)
+        }
+    }
+
+    /// Retrieve or set the value for a given storage key.
+    /// - Parameters:
+    ///   - source: The storage key type.
+    ///   - defaultValue: A default value that is returned if there isn't a value stored.
+    /// - Returns: The value or the default value if there isn't currently a value stored in the context.
+    @_documentation(visibility: internal)
+    public subscript<Source: TaskStorageKey>(_ source: Source.Type, default defaultValue: @autoclosure () -> Source.Value) -> Source.Value {
+        get {
+            (try? userInfo.get(source, cache: &userInfoCache)) ?? defaultValue()
+        }
+        set {
+            try? userInfo.set(source, value: newValue, cache: &userInfoCache)
+        }
+    }
 }
 
 
@@ -528,10 +556,10 @@ extension Task {
         @_documentation(visibility: internal)
         public subscript<Source: TaskStorageKey>(_ source: Source.Type) -> Source.Value? {
             get {
-                userInfo.get(source, cache: &box.userInfoCache)
+                try? userInfo.get(source, cache: &box.userInfoCache)
             }
             set {
-                userInfo.set(source, value: newValue, cache: &box.userInfoCache)
+                try? userInfo.set(source, value: newValue, cache: &box.userInfoCache)
             }
         }
 
@@ -544,10 +572,10 @@ extension Task {
         @_documentation(visibility: internal)
         public subscript<Source: TaskStorageKey>(_ source: Source.Type, default defaultValue: @autoclosure () -> Source.Value) -> Source.Value {
             get {
-                userInfo.get(source, cache: &box.userInfoCache) ?? defaultValue()
+                (try? userInfo.get(source, cache: &box.userInfoCache)) ?? defaultValue()
             }
             set {
-                userInfo.set(source, value: newValue, cache: &box.userInfoCache)
+                try? userInfo.set(source, value: newValue, cache: &box.userInfoCache)
             }
         }
         

--- a/Sources/SpeziScheduler/UserInfo/Property.swift
+++ b/Sources/SpeziScheduler/UserInfo/Property.swift
@@ -46,6 +46,7 @@ import SpeziFoundation
 @attached(accessor, names: named(get), named(set))
 @attached(peer, names: prefixed(__Key_))
 public macro Property<Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>(
-    coding: UserStorageCoding<Encoder, Decoder> = .propertyList
+    coding: UserStorageCoding<Encoder, Decoder> = .propertyList,
+    storageIdentifier: StaticString? = nil
 ) = #externalMacro(module: "SpeziSchedulerMacros", type: "UserStorageEntryMacro")
 #endif

--- a/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
+++ b/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
@@ -21,8 +21,8 @@ struct SingleValueWrapper<Value: Codable>: Codable {
     }
 }
 
-
-struct UserInfoStorage<Anchor: RepositoryAnchor> {
+@_spi(APISupport)
+public struct UserInfoStorage<Anchor: RepositoryAnchor> { // swiftlint:disable:this missing_docs
     struct RepositoryCache {
         var repository = ValueRepository<Anchor>()
     }
@@ -60,7 +60,7 @@ extension UserInfoStorage {
             cache.repository.set(source, value: value.value)
             return value.value
         } catch {
-            logger.error("Failed to decode userInfo value for \(source) from data \(data): \(error)")
+//            logger.error("Failed to decode userInfo value for \(source) from data \(data): \(error)")
             return nil
         }
     }
@@ -73,7 +73,7 @@ extension UserInfoStorage {
                 let encoder = source.coding.encoder
                 userInfo[source.identifier] = try encoder.encode(SingleValueWrapper(value: newValue))
             } catch {
-                logger.error("Failed to encode userInfo value \(String(describing: newValue)) for \(source): \(error)")
+//                logger.error("Failed to encode userInfo value \(String(describing: newValue)) for \(source): \(error)")
             }
         } else {
             userInfo.removeValue(forKey: source.identifier)
@@ -83,11 +83,11 @@ extension UserInfoStorage {
 
 
 extension UserInfoStorage: RawRepresentable {
-    var rawValue: [String: Data] {
+    public var rawValue: [String: Data] {
         userInfo
     }
 
-    init(rawValue: [String: Data]) {
+    public init(rawValue: [String: Data]) {
         self.userInfo = rawValue
     }
 }
@@ -96,14 +96,14 @@ extension UserInfoStorage: Codable {}
 
 
 extension UserInfoStorage: Equatable {
-    static func == (lhs: UserInfoStorage<Anchor>, rhs: UserInfoStorage<Anchor>) -> Bool {
+    public static func == (lhs: UserInfoStorage<Anchor>, rhs: UserInfoStorage<Anchor>) -> Bool {
         lhs.userInfo == rhs.userInfo
     }
 }
 
 
 extension UserInfoStorage: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         "UserInfoStorage(\(userInfo.keys.joined(separator: ", ")))"
     }
 }

--- a/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
+++ b/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
@@ -8,12 +8,11 @@
 
 #if canImport(Darwin)
 import Foundation
-import OSLog
 import SpeziFoundation
 
 
 /// Property lists can never store single values (unlike JSON). Therefore, we always embed values into a container.
-struct SingleValueWrapper<Value: Codable>: Codable {
+private struct SingleValueWrapper<Value: Codable>: Codable {
     let value: Value
 
     init(value: Value) {
@@ -22,16 +21,12 @@ struct SingleValueWrapper<Value: Codable>: Codable {
 }
 
 @_spi(APISupport)
-public struct UserInfoStorage<Anchor: RepositoryAnchor> { // swiftlint:disable:this missing_docs
+public struct UserInfoStorage<Anchor: RepositoryAnchor>: Codable {
     struct RepositoryCache {
         var repository = ValueRepository<Anchor>()
     }
 
-    private var userInfo: [String: Data] = [:]
-
-    private var logger: Logger {
-        Logger(subsystem: "edu.stanford.spezi.scheduler", category: "\(Self.self)")
-    }
+    private(set) var userInfo: [String: Data] = [:]
 
     init() {
         self.userInfo = [:]
@@ -44,55 +39,40 @@ public struct UserInfoStorage<Anchor: RepositoryAnchor> { // swiftlint:disable:t
 
 
 extension UserInfoStorage {
-    func get<Source: _UserInfoKey<Anchor>>(_ source: Source.Type, cache: inout RepositoryCache) -> Source.Value? {
+    func get<Source: _UserInfoKey<Anchor>>(
+        _ source: Source.Type,
+        cache: inout RepositoryCache
+    ) throws -> Source.Value? {
         if let value = cache.repository.get(source) {
             return value
         }
-
         guard let data = userInfo[source.identifier] else {
             return nil
         }
-
         do {
             let decoder = source.coding.decoder
             let value = try decoder.decode(SingleValueWrapper<Source.Value>.self, from: data)
-
             cache.repository.set(source, value: value.value)
             return value.value
         } catch {
-//            logger.error("Failed to decode userInfo value for \(source) from data \(data): \(error)")
             return nil
         }
     }
 
-    mutating func set<Source: _UserInfoKey<Anchor>>(_ source: Source.Type, value newValue: Source.Value?, cache: inout RepositoryCache) {
+    mutating func set<Source: _UserInfoKey<Anchor>>(
+        _ source: Source.Type,
+        value newValue: Source.Value?,
+        cache: inout RepositoryCache
+    ) throws {
         cache.repository.set(source, value: newValue)
-
         if let newValue {
-            do {
-                let encoder = source.coding.encoder
-                userInfo[source.identifier] = try encoder.encode(SingleValueWrapper(value: newValue))
-            } catch {
-//                logger.error("Failed to encode userInfo value \(String(describing: newValue)) for \(source): \(error)")
-            }
+            let encoder = source.coding.encoder
+            userInfo[source.identifier] = try encoder.encode(SingleValueWrapper(value: newValue))
         } else {
             userInfo.removeValue(forKey: source.identifier)
         }
     }
 }
-
-
-extension UserInfoStorage: RawRepresentable {
-    public var rawValue: [String: Data] {
-        userInfo
-    }
-
-    public init(rawValue: [String: Data]) {
-        self.userInfo = rawValue
-    }
-}
-
-extension UserInfoStorage: Codable {}
 
 
 extension UserInfoStorage: Equatable {

--- a/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
+++ b/Sources/SpeziScheduler/UserInfo/UserInfoStorage.swift
@@ -49,14 +49,10 @@ extension UserInfoStorage {
         guard let data = userInfo[source.identifier] else {
             return nil
         }
-        do {
-            let decoder = source.coding.decoder
-            let value = try decoder.decode(SingleValueWrapper<Source.Value>.self, from: data)
-            cache.repository.set(source, value: value.value)
-            return value.value
-        } catch {
-            return nil
-        }
+        let decoder = source.coding.decoder
+        let value = try decoder.decode(SingleValueWrapper<Source.Value>.self, from: data)
+        cache.repository.set(source, value: value.value)
+        return value.value
     }
 
     mutating func set<Source: _UserInfoKey<Anchor>>(

--- a/Sources/SpeziSchedulerMacros/UserStorageEntryMacro.swift
+++ b/Sources/SpeziSchedulerMacros/UserStorageEntryMacro.swift
@@ -111,6 +111,32 @@ extension UserStorageEntryMacro: PeerMacro {
                 declName: DeclReferenceExprSyntax(baseName: .identifier("propertyList"))
             ))
         }
+        
+        let storageIdentifier: String
+        if case .argumentList(let arguments) = node.arguments,
+           let storageIdentArg = arguments.first(where: { $0.label?.text == "storageIdentifier" }) {
+            guard let stringLiteral = storageIdentArg.expression.as(StringLiteralExprSyntax.self) else {
+                throw DiagnosticsError(
+                    syntax: storageIdentArg,
+                    message: "Must be a String literal!",
+                    id: .invalidSyntax
+                )
+            }
+            storageIdentifier = try stringLiteral.segments.reduce(into: "") { result, segment in
+                switch segment {
+                case .stringSegment(let segment):
+                    result += segment.content.text
+                case .expressionSegment:
+                    throw DiagnosticsError(
+                        syntax: stringLiteral,
+                        message: "String isn't allowed to contain interpolations!",
+                        id: .invalidSyntax
+                    )
+                }
+            }
+        } else {
+            storageIdentifier = identifier.text
+        }
 
         let keyProtocol: TokenSyntax
 
@@ -130,7 +156,6 @@ extension UserStorageEntryMacro: PeerMacro {
                 id: .invalidSyntax
             )
         }
-
 
         let valueTypeInitializer: TypeSyntax
 
@@ -162,7 +187,7 @@ extension UserStorageEntryMacro: PeerMacro {
             )
 
             """
-            static let identifier: String = "\(identifier)"
+            static let identifier: String = \(StringLiteralExprSyntax(content: storageIdentifier))
             static let coding = \(codingExpression)
             """
         }

--- a/Sources/SpeziSchedulerMacros/UserStorageEntryMacro.swift
+++ b/Sources/SpeziSchedulerMacros/UserStorageEntryMacro.swift
@@ -115,24 +115,27 @@ extension UserStorageEntryMacro: PeerMacro {
         let storageIdentifier: String
         if case .argumentList(let arguments) = node.arguments,
            let storageIdentArg = arguments.first(where: { $0.label?.text == "storageIdentifier" }) {
-            guard let stringLiteral = storageIdentArg.expression.as(StringLiteralExprSyntax.self) else {
+            if let stringLiteral = storageIdentArg.expression.as(StringLiteralExprSyntax.self) {
+                storageIdentifier = try stringLiteral.segments.reduce(into: "") { result, segment in
+                    switch segment {
+                    case .stringSegment(let segment):
+                        result += segment.content.text
+                    case .expressionSegment:
+                        throw DiagnosticsError(
+                            syntax: stringLiteral,
+                            message: "String isn't allowed to contain interpolations!",
+                            id: .invalidSyntax
+                        )
+                    }
+                }
+            } else if storageIdentArg.expression.is(NilLiteralExprSyntax.self) {
+                storageIdentifier = identifier.text
+            } else {
                 throw DiagnosticsError(
                     syntax: storageIdentArg,
                     message: "Must be a String literal!",
                     id: .invalidSyntax
                 )
-            }
-            storageIdentifier = try stringLiteral.segments.reduce(into: "") { result, segment in
-                switch segment {
-                case .stringSegment(let segment):
-                    result += segment.content.text
-                case .expressionSegment:
-                    throw DiagnosticsError(
-                        syntax: stringLiteral,
-                        message: "String isn't allowed to contain interpolations!",
-                        id: .invalidSyntax
-                    )
-                }
             }
         } else {
             storageIdentifier = identifier.text

--- a/Tests/SpeziSchedulerTests/SchedulerTests.swift
+++ b/Tests/SpeziSchedulerTests/SchedulerTests.swift
@@ -10,6 +10,7 @@
 
 import Spezi
 @_spi(TestingSupport)
+@_spi(APISupport)
 @testable import SpeziScheduler
 import SpeziTesting
 import SwiftData
@@ -860,6 +861,58 @@ struct SchedulerTests { // swiftlint:disable:this type_body_length
             task3.title == "Task 3 \(placeholder: .double) \(placeholder: .float) \(placeholder: .int) \(placeholder: .uint) \(placeholder: .object)"
         )
         #expect(String(localized: task3.instructions) == "Task 3")
+    }
+    
+    
+    @Test
+    @MainActor
+    func userInfoPersistance() throws {
+        struct TaskContextKey: TaskStorageKey, _UserInfoKey<TaskAnchor> {
+            typealias Value = Int
+            static let identifier = "tKey1"
+            static let coding = UserStorageCoding.json
+        }
+        struct OutcomeContextKey: OutcomeStorageKey, _UserInfoKey<OutcomeAnchor> {
+            typealias Value = Int
+            static let identifier = "oKey1"
+            static let coding = UserStorageCoding.json
+        }
+        do {
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+            var storage = UserInfoStorage<TaskAnchor>()
+            var cache = UserInfoStorage<TaskAnchor>.RepositoryCache()
+            try storage.set(TaskContextKey.self, value: 52, cache: &cache)
+            #expect(storage.userInfo == ["tKey1": Data(#"{"value":52}"#.utf8)])
+            let storageJson = try jsonEncoder.encode(storage)
+            #expect(String(decoding: storageJson, as: UTF8.self) == #"{"userInfo":{"tKey1":"\#(Data(#"{"value":52}"#.utf8).base64EncodedString())"}}"#)
+        }
+        let scheduler = Scheduler(persistence: .inMemory)
+        withDependencyResolution {
+            scheduler
+        }
+        try scheduler.createOrUpdateTask(
+            id: "t0",
+            title: "T",
+            instructions: "I",
+            schedule: .weekly(hour: 0, minute: 0, startingAt: .now)
+        ) { context in
+            context[TaskContextKey.self] = 7
+        }
+        #expect(try scheduler.queryAllTasks().count == 1)
+        let events = try scheduler.queryEvents(for: Calendar.current.rangeOfDay(for: .now))
+        #expect(events.count == 1)
+        let event = try #require(events.first)
+        #expect(event.task[TaskContextKey.self] == 7)
+        #expect(!event.isCompleted)
+        #expect(event.outcome == nil)
+        try event.complete { outcome in
+            outcome[OutcomeContextKey.self] = 5
+        }
+        #expect(event.isCompleted)
+        #expect(event.outcome != nil)
+        #expect(event.outcome?[OutcomeContextKey.self] == 5)
+        try scheduler.context.save()
     }
 }
 

--- a/Tests/SpeziSchedulerTests/UserStorageEntryMacroTests.swift
+++ b/Tests/SpeziSchedulerTests/UserStorageEntryMacroTests.swift
@@ -411,6 +411,72 @@ struct UserStorageEntryMacroTests { // swiftlint:disable:this type_body_length
             macros: testMacros
         )
     }
+    
+    
+    @Test
+    func customStorageIdentifier() {
+        assertMacroExpansion(
+            """
+            extension Task.Context {
+                @Property(storageIdentifier: "legacyName") var testMacro: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension Task.Context {
+                var testMacro: String? {
+                    get {
+                        self[__Key_testMacro.self]
+                    }
+                    set {
+                        self[__Key_testMacro.self] = newValue
+                    }
+                }
+            
+                private struct __Key_testMacro: TaskStorageKey {
+                    typealias Value = String
+            
+                    static let identifier: String = "legacyName"
+                    static let coding = UserStorageCoding.propertyList
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    
+    @Test
+    func customStorageIdentifierNilLiteral() {
+        assertMacroExpansion(
+            """
+            extension Task.Context {
+                @Property(storageIdentifier: nil) var testMacro: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension Task.Context {
+                var testMacro: String? {
+                    get {
+                        self[__Key_testMacro.self]
+                    }
+                    set {
+                        self[__Key_testMacro.self] = newValue
+                    }
+                }
+            
+                private struct __Key_testMacro: TaskStorageKey {
+                    typealias Value = String
+            
+                    static let identifier: String = "testMacro"
+                    static let coding = UserStorageCoding.propertyList
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
# fixes; task version history mutation APIs


## :gear: Release Notes
- fixed: `Schedule` equality no longer yields false negatives for schedules containing identical recurrence rules
- new: added several SPI-guarded APIs for rewriting a task's version history. intended for merging duplicate task versions.


## :books: Documentation
yes


## :white_check_mark: Testing
no


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
