### PR TITLE
fix: hoist Range<Date> bounds out of #Predicate capture (iOS 26.5 SwiftData)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ Spezi Scheduler contributors
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Andreas Bauer](https://github.com/bauer-andreas)
 * [Lukas Kollmer](https://github.com/lukaskollmer)
+* [Vegard Bolstad](https://github.com/VegardBolstad)

--- a/Sources/SpeziScheduler/Scheduler.swift
+++ b/Sources/SpeziScheduler/Scheduler.swift
@@ -922,14 +922,18 @@ extension Scheduler {
     }
 
     private func queryOutcomes(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> [Outcome] {
+        // `range.contains(outcome.occurrenceStartDate)` can't be used directly in a #Predicate (it filters out
+        // everything, even when the start date falls into the range — see PR #55 for the original workaround).
+        // Additionally, on iOS 26.5+, SwiftData rejects a captured `Range<Date>` constant outright with
+        // `SwiftDataError.unsupportedPredicate("Captured/constant values of type 'Range<Date>' are not supported")`,
+        // so the bounds are hoisted into plain `Date` locals before the predicate to keep only supported types
+        // in the captured environment.
+        // See also: https://github.com/StanfordSpezi/SpeziScheduler/pull/55#issuecomment-2667153659
+        let lowerBound = range.lowerBound
+        let upperBound = range.upperBound
         var descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
-                // Since, for some reason, `range.contains(outcome.occurrenceStartDate)` doesn't work in a #Predicate
-                // (it just filters out everything, even if the start date does in fact fall into the range),
-                // we instead need to rewrite what could otherwise be a `contains` call into explicit checks against the range's lower and upper bound.
-                // See also: https://github.com/StanfordSpezi/SpeziScheduler/pull/55#issuecomment-2667153659
-                // swiftlint:disable:next line_length
-                range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
+                lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < upperBound && taskPredicate.evaluate(outcome.task)
             }
         )
         descriptor.relationshipKeyPathsForPrefetching = [\.task]
@@ -949,14 +953,13 @@ extension Scheduler {
     }
 
     private func queryOutcomeIdentifiers(for range: Range<Date>, predicate taskPredicate: Predicate<Task>) throws -> Set<PersistentIdentifier> {
+        // See `queryOutcomes(for:predicate:)` above for the rationale behind hoisting the range bounds
+        // into `Date` locals before the #Predicate (iOS 26.5+ SwiftData rejects captured `Range<Date>`).
+        let lowerBound = range.lowerBound
+        let upperBound = range.upperBound
         let descriptor = FetchDescriptor<Outcome>(
             predicate: #Predicate { outcome in
-                // Since, for some reason, `range.contains(outcome.occurrenceStartDate)` doesn't work in a #Predicate
-                // (it just filters out everything, even if the start date does in fact fall into the range),
-                // we instead need to rewrite what could otherwise be a `contains` call into explicit checks against the range's lower and upper bound.
-                // See also: https://github.com/StanfordSpezi/SpeziScheduler/pull/55#issuecomment-2667153659
-                // swiftlint:disable:next line_length
-                range.lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < range.upperBound && taskPredicate.evaluate(outcome.task)
+                lowerBound <= outcome.occurrenceStartDate && outcome.occurrenceStartDate < upperBound && taskPredicate.evaluate(outcome.task)
             }
         )
         return try Set(context.fetchIdentifiers(descriptor))


### PR DESCRIPTION
## :gear: Release Notes

- fixed: `Scheduler.queryOutcomes(for:predicate:)` and `Scheduler.queryOutcomeIdentifiers(for:predicate:)` no longer fail with `SwiftDataError.unsupportedPredicate` on iOS 26.5+. The bounds of the `Range<Date>` argument are now hoisted into plain `Date` locals before the `#Predicate`, so only supported types are captured.

## :pencil: Description

### What's broken

On iOS 26.5+, any code path that reaches `Scheduler.queryOutcomes(for:predicate:)` or `Scheduler.queryOutcomeIdentifiers(for:predicate:)` (so, transitively, `queryEvents(for: Range<Date>, …)` and the `SpeziSchedulerUI` schedule views built on it) throws:

```
SwiftDataError(_error: SwiftData.SwiftDataError._Error.unsupportedPredicate,
  _explanation: "Unsupported Predicate: Captured/constant values of
                 type 'Range<Date>' are not supported")
```

### Root cause

Both private methods already decompose `range.contains(occurrenceStartDate)` into explicit lower-/upper-bound checks (per #55) — but they still **capture the whole `Range<Date>` value** inside the `#Predicate` body to read `.lowerBound` / `.upperBound`:

```swift
predicate: #Predicate { outcome in
    range.lowerBound <= outcome.occurrenceStartDate
        && outcome.occurrenceStartDate < range.upperBound
        && taskPredicate.evaluate(outcome.task)
}
```

iOS 26.5's SwiftData predicate translator is stricter than earlier SDKs and rejects `Range<Date>` as a captured/constant type outright. The earlier `range.contains` rewrite from #55 fixed the *semantics* but not the *capture type*.

### Fix

Hoist `range.lowerBound` and `range.upperBound` into `Date` locals **before** the `#Predicate`, so the predicate only captures `Date` (which SwiftData supports):

```swift
let lowerBound = range.lowerBound
let upperBound = range.upperBound
let descriptor = FetchDescriptor<Outcome>(
    predicate: #Predicate { outcome in
        lowerBound <= outcome.occurrenceStartDate
            && outcome.occurrenceStartDate < upperBound
            && taskPredicate.evaluate(outcome.task)
    }
)
```

Applied to both `queryOutcomes(for:predicate:)` and `queryOutcomeIdentifiers(for:predicate:)`. The in-code comment now documents both the original `range.contains` workaround (#55) **and** the iOS 26.5+ capture-type rejection, so a future refactor doesn't quietly reintroduce either trap. No public-API change; predicate semantics are identical on earlier SDKs.

### Reproduction

The error surfaces non-deterministically because it fires inside an async predicate evaluation kicked off by the `Scheduler` `Module`'s lifecycle once the schedule store is exercised. From a host app:

1. Use `Scheduler()` with on-disk persistence (default), plus an outcome-producing task. Then query: `try scheduler.queryEvents(for: someRange: Range<Date>)`.
2. Run on iOS 26.5 (simulator or device).
3. Observe: `SwiftDataError.unsupportedPredicate("Captured/constant values of type 'Range<Date>' are not supported")`.
4. With the patch in this PR: query returns successfully.

### Verification on this PR

- **macOS** — `swift test` (full SpeziScheduler test suite): **30 / 30 tests pass** (no regression).
- **iOS 26.5 sim** — `xcodebuild test -scheme SpeziScheduler-Package -only-testing:SpeziSchedulerTests` on iPad mini (A17 Pro) iOS 26.5 (`23F77`, Xcode 26.3): **21 / 21 tests pass** post-fix.
- **iOS 26.5 sim, *pre-fix*** — same suite, same destination: also **21 / 21 pass**. The existing `SpeziSchedulerTests` cover `queryEvents(for: Range<Date>)` but only with `.inMemory` persistence and within the test runner's synchronous test scope, neither of which reaches the predicate-translator path that fires on iOS 26.5+ in a real on-disk + `Module`-lifecycle context. The fix is value-preserving for those (still-green) paths and additionally unblocks the on-disk path that triggers the failure in production. **If maintainers want a dedicated regression test** that exercises on-disk persistence + outcome-completion + ranged query, I'm happy to add one in this PR — flagged separately because adding it requires a small new fixture pattern that didn't already exist in the suite.
- **SwiftLint --strict** — clean (the previous `swiftlint:disable:next line_length` directives are no longer needed; with `range.` removed from the predicate body, the line drops from 153 to 141 chars).

### Cross-reference

This fix unblocks [`VegardBolstad/DrawnToMind#212`](https://github.com/VegardBolstad/DrawnToMind/issues/212), where the failure was originally observed against `SpeziScheduler` 1.2.18.

## :books: Documentation

The two in-code comments above each affected method capture the rationale (both the #55 `range.contains` history and the iOS 26.5 capture-type rejection). No external documentation changes needed.

## :white_check_mark: Testing

The existing test suite passes unchanged. A behaviour-test that pins the iOS 26.5 path specifically would only fail-fast on iOS 26.5+ (macOS SwiftData tolerated the capture all along), so the dominant tripwire is the in-code comment. Happy to add an on-disk + ranged-query regression test on request — see the "Verification" note above.

## :pencil: Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):

- [x] I agree to follow the Code of Conduct and Contributing Guidelines.
